### PR TITLE
reconnect on Connection Failure in MongoDB + dead workers cleanup on startup 

### DIFF
--- a/lib/qu.rb
+++ b/lib/qu.rb
@@ -13,7 +13,7 @@ module Qu
   extend SingleForwardable
   extend self
 
-  attr_accessor :backend, :failure, :logger
+  attr_accessor :backend, :failure, :logger, :max_retries_on_connection_failure, :retry_frequency_on_connection_failure
 
   def_delegators :backend, :length, :queues, :reserve, :clear, :connection=
 
@@ -33,6 +33,8 @@ end
 Qu.configure do |c|
   c.logger = Logger.new(STDOUT)
   c.logger.level = Logger::INFO
+  c.max_retries_on_connection_failure = 5
+  c.retry_frequency_on_connection_failure = 1
 end
 
 require 'qu/railtie' if defined?(Rails)

--- a/lib/qu/worker.rb
+++ b/lib/qu/worker.rb
@@ -52,6 +52,7 @@ module Qu
 
     def start
       logger.warn "Worker #{id} starting"
+      prune_dead_workers
       handle_signals
       Qu.backend.register_worker(self)
       loop { work }
@@ -73,5 +74,24 @@ module Qu
     def hostname
       @hostname ||= `hostname`.strip
     end
+    
+    private
+      def prune_dead_workers
+        all_workers = Qu.backend.workers
+        local_workers_pids = worker_pids unless all_workers.empty?
+        
+        all_workers.each do |worker|
+          next if worker.hostname != self.hostname
+          next if local_workers_pids.include?(worker.pid)
+          logger.info "Pruning dead worker: #{worker.id}"
+          Qu.backend.unregister_worker(worker)
+        end
+      end
+      
+      def worker_pids
+        `ps -A -o pid,command | grep '[q]u:work'`.split("\n").map do |line|
+            line.split(' ')[0]
+        end
+      end
   end
 end

--- a/spec/qu/worker_spec.rb
+++ b/spec/qu/worker_spec.rb
@@ -52,7 +52,20 @@ describe Qu::Worker do
       it 'should unregister worker' do
         Qu.backend.should_receive(:unregister_worker).with(subject)
         subject.start
+      end  
+    end
+    
+    context "unregister dead workers (crash recovery)" do
+      let(:worker) { Qu::Worker.new }
+      
+      it "prune dead worker" do
+        Qu.backend.register_worker(worker)
+        Qu.backend.stub(:workers).and_return([worker])
+        
+        Qu.backend.should_receive(:unregister_worker).with(worker)
+        subject.start
       end
+      
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'qu/backend/spec'
 RSpec.configure do |config|
   config.before do
     Qu.backend = mock('a backend', :reserve => nil, :failed => nil, :completed => nil,
-      :register_worker => nil, :unregister_worker => nil)
+      :register_worker => nil, :unregister_worker => nil, :workers => [])
     Qu.failure = nil
   end
 end


### PR DESCRIPTION
Hi.
1. Implemented reconnect on Connection Failure in MongoDB backend.
   
   This is useful in production with replica sets, since it take 2-10 seconds to replica set to elect new master.
   
   I don't use redis so I don't implemented this for redis adapter.
   
   Also added 2 config values: Qu.max_retries_on_connection_failure and Qu.retry_frequency_on_connection_failure, it would be great to add them to read me.
2. Implemented Dead workers cleanup on startup.
   Used unregister_worker so will not work due issue #13.
   After you decide what you want to pass to unregister_worker method you need to change worker to worker.id on line 87 in worker.rb if you decide to pass id, or do nothing if you decide to pass worker object.

Thanks.
