### PR TITLE
Add support for Rails 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Decide which backend you want to use and add the gem for it to your `Gemfile`.
 ``` ruby
 gem 'qu-redis'
 ```
+If you are using a version of Rails that does not support Railtie (so, not Rails 3), you need to create a rake task to load the Qu tasks. So, create `lib/tasks/qu.rake` with the contents
+
+``` ruby
+require 'qu/tasks'
+```
 
 That's all you need to do!
 

--- a/lib/qu.rb
+++ b/lib/qu.rb
@@ -35,4 +35,11 @@ Qu.configure do |c|
   c.logger.level = Logger::INFO
 end
 
-require 'qu/railtie' if defined?(Rails)
+if defined?(Rails)
+  if defined?(Rails::Railtie)
+    require 'qu/railtie'
+  else
+    Qu.logger = Rails.logger
+  end
+end
+


### PR DESCRIPTION
Currently if one wants to use Qu with Rails, Qu requires Railtie and thus Rails 3. I removed the requirement for Railtie and added information to the README for what needs to be done if you want to use it with Rails 2.
