### PR TITLE
Enqueue a clone of the payload when testing for already reserved jobs 

### DIFF
--- a/lib/qu/backend/spec.rb
+++ b/lib/qu/backend/spec.rb
@@ -112,7 +112,7 @@ shared_examples_for 'a backend' do
     end
 
     it 'should not return an already reserved job' do
-      subject.enqueue(payload)
+      subject.enqueue(payload.dup)
       subject.reserve(worker).id.should_not == subject.reserve(worker).id
     end
 


### PR DESCRIPTION
When used with a backend where the payload.id doesn't need to be unique this could lead to two different jobs with the same id being returned.
