### PR TITLE
Store error details on failure

### DIFF
--- a/lib/qu/backend/mongo.rb
+++ b/lib/qu/backend/mongo.rb
@@ -92,7 +92,7 @@ module Qu
       def failed(payload, error)
         doc = {
           :_id => payload.id, :klass => payload.klass.to_s, :args => payload.args, :queue => payload.queue,
-          exception: error.class.to_s, error: error.to_s, backtrace: error.backtrace
+          exception: error.class.to_s, error: error.to_s, backtrace: Array(error.backtrace).join("\n")
         }
         jobs('failed').insert(doc)
       end

--- a/lib/qu/backend/mongo.rb
+++ b/lib/qu/backend/mongo.rb
@@ -90,7 +90,11 @@ module Qu
       end
 
       def failed(payload, error)
-        jobs('failed').insert(:_id => payload.id, :klass => payload.klass.to_s, :args => payload.args, :queue => payload.queue)
+        doc = {
+          :_id => payload.id, :klass => payload.klass.to_s, :args => payload.args, :queue => payload.queue,
+          exception: error.class.to_s, error: error.to_s, backtrace: error.backtrace
+        }
+        jobs('failed').insert(doc)
       end
 
       def completed(payload)
@@ -99,6 +103,7 @@ module Qu
       def requeue(id)
         logger.debug "Requeuing job #{id}"
         doc = jobs('failed').find_and_modify(:query => {:_id => id}, :remove => true) || raise(::Mongo::OperationFailure)
+        doc.delete_if {|k,v| %w[backtrace error exception].include? k }
         jobs(doc.delete('queue')).insert(doc)
         doc['id'] = doc.delete('_id')
         Payload.new(doc)

--- a/lib/qu/backend/spec.rb
+++ b/lib/qu/backend/spec.rb
@@ -220,6 +220,15 @@ shared_examples_for 'a backend' do
         p.args.should == payload.args
       end
 
+      it 'should remove the exception, error and backtrace' do
+        subject.requeue(payload.id)
+        p = subject.reserve(worker)
+        p.should be_instance_of(Qu::Payload)
+        p.exception.should be_nil
+        p.error.should be_nil
+        p.backtrace.should be_nil
+      end
+
       it 'should remove the job from the failed jobs' do
         subject.length('failed').should == 1
         subject.requeue(payload.id)

--- a/spec/qu/backend/mongo_spec.rb
+++ b/spec/qu/backend/mongo_spec.rb
@@ -55,6 +55,21 @@ describe Qu::Backend::Mongo do
     end
   end
 
+  describe 'failure' do
+    let(:payload) { Qu::Payload.new(:id => '1', :klass => SimpleJob) }
+
+    it 'should store the exception, error and backtrace' do
+      jobs = mock('jobs')
+      subject.stub(:jobs).and_return(jobs)
+      jobs.should_receive(:insert) do |attrs|
+        attrs[:exception].should eql 'Exception'
+        attrs[:error].should eql 'an error'
+        attrs[:backtrace].should eql nil
+      end
+      subject.failed(payload, Exception.new('an error'))
+    end
+  end
+
   describe 'reserve' do
     let(:worker) { Qu::Worker.new }
 

--- a/spec/qu/backend/mongo_spec.rb
+++ b/spec/qu/backend/mongo_spec.rb
@@ -64,7 +64,7 @@ describe Qu::Backend::Mongo do
       jobs.should_receive(:insert) do |attrs|
         attrs[:exception].should eql 'Exception'
         attrs[:error].should eql 'an error'
-        attrs[:backtrace].should eql nil
+        attrs[:backtrace].should eql ''
       end
       subject.failed(payload, Exception.new('an error'))
     end


### PR DESCRIPTION
Hello,

In migrating from Redis, one feature I found missing was the inclusion of error details with failed jobs. I've found this to be preferable to using Airbrake/Exceptional in a project where the success of a job can't be guaranteed.

The attached changes to the Mongo backend store errors along with the failed job. It also ensures they aren't included on requeue.
