### PR TITLE
Requeue is not in use. Removing it from spec and use.

### DIFF
--- a/lib/qu/backend/mongo.rb
+++ b/lib/qu/backend/mongo.rb
@@ -96,16 +96,6 @@ module Qu
       def completed(payload)
       end
 
-      def requeue(id)
-        logger.debug "Requeuing job #{id}"
-        doc = jobs('failed').find_and_modify(:query => {:_id => id}, :remove => true) || raise(::Mongo::OperationFailure)
-        jobs(doc.delete('queue')).insert(doc)
-        doc['id'] = doc.delete('_id')
-        Payload.new(doc)
-      rescue ::Mongo::OperationFailure
-        false
-      end
-
       def register_worker(worker)
         logger.debug "Registering worker #{worker.id}"
         self[:workers].insert(worker.attributes.merge(:id => worker.id))

--- a/lib/qu/backend/redis.rb
+++ b/lib/qu/backend/redis.rb
@@ -71,17 +71,6 @@ module Qu
         redis.del("job:#{payload.id}")
       end
 
-      def requeue(id)
-        logger.debug "Requeuing job #{id}"
-        if payload = get(id)
-          redis.lrem('queue:failed', 1, id)
-          redis.rpush("queue:#{payload.queue}", id)
-          payload
-        else
-          false
-        end
-      end
-
       def register_worker(worker)
         logger.debug "Registering worker #{worker.id}"
         redis.set("worker:#{worker.id}", encode(worker.attributes))

--- a/lib/qu/backend/spec.rb
+++ b/lib/qu/backend/spec.rb
@@ -200,44 +200,6 @@ shared_examples_for 'a backend' do
     end
   end
 
-  describe 'requeue' do
-    context 'with a failed job' do
-      before do
-        subject.enqueue(payload)
-        subject.reserve(worker).id.should == payload.id
-        subject.failed(payload, Exception.new)
-      end
-
-      it 'should add the job back on the queue' do
-        subject.length(payload.queue).should == 0
-        subject.requeue(payload.id)
-        subject.length(payload.queue).should == 1
-
-        p = subject.reserve(worker)
-        p.should be_instance_of(Qu::Payload)
-        p.id.should == payload.id
-        p.klass.should == payload.klass
-        p.args.should == payload.args
-      end
-
-      it 'should remove the job from the failed jobs' do
-        subject.length('failed').should == 1
-        subject.requeue(payload.id)
-        subject.length('failed').should == 0
-      end
-
-      it 'should return the job' do
-        subject.requeue(payload.id).id.should == payload.id
-      end
-    end
-
-    context 'without a failed job' do
-      it 'should return false' do
-        subject.requeue('1').should be_false
-      end
-    end
-  end
-
   describe 'register_worker' do
     it 'should add worker to array of workers' do
       subject.register_worker(worker)


### PR DESCRIPTION
When workers trap signals, they raise Abort. 

Abort is rescued and release is called with full payload. 

Requeue never is used so it should be safe to remove. Requeueing by id is an awkward api for any pure queueing system anyway as most queues just push and pop and have no way to access something by an individual id.
