### PR TITLE
Fixing Immediate backend to satisfy the backend interface

### DIFF
--- a/lib/qu/backend/immediate.rb
+++ b/lib/qu/backend/immediate.rb
@@ -13,6 +13,29 @@ module Qu
 
       def failed(payload, error)
       end
+
+      def register_worker(*)
+      end
+
+      def unregister_worker(*)
+      end
+
+      def clear(*)
+      end
+
+      def connection=(*)
+      end
+
+      def reserve(*)
+      end
+
+      def length(*)
+        0
+      end
+
+      def queues(*)
+        ["default"]
+      end
     end
   end
 end


### PR DESCRIPTION
The Immediate backend is broken because the rest of the framework is calling methods that don't exist. This is meant to fix it.
