### PR TITLE
Moving to debugger which is working in 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 group :test do
   gem 'SystemTimer',  :platform => :mri_18
   gem 'ruby-debug',   :platform => :mri_18
-  gem 'ruby-debug19', :platform => :mri_19, :require => 'ruby-debug'
+  gem 'debugger',     :platform => :mri_19
   gem 'rake'
   gem 'rspec', '~> 2.0'
   gem 'guard-rspec'


### PR DESCRIPTION
I pulled out the MultiJson feature-detect commit so this should fix running the tests against 1.9
