### PR TITLE
Adding v0.1.5 deprecation warnings

### DIFF
--- a/lib/qu.rb
+++ b/lib/qu.rb
@@ -36,6 +36,8 @@ Qu.configure do |c|
 end
 
 if defined?(Rails)
+  warn "#{Kernel.caller[1]}: [DEPRECATION] v1.0 will require you use the 'qu-rails' gem for rails hooks to be autoloaded"
+
   if defined?(Rails::Railtie)
     require 'qu/railtie'
   else

--- a/lib/qu/version.rb
+++ b/lib/qu/version.rb
@@ -1,3 +1,3 @@
 module Qu
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
This is the deprecation of the rails specific code in qu.rb. A follow up pull request will have the actual move and a version bump.
