### PR TITLE
Qu rails

### DIFF
--- a/lib/qu-rails.rb
+++ b/lib/qu-rails.rb
@@ -1,0 +1,15 @@
+require "qu"
+
+Qu.configure do |c|
+  c.logger = Logger.new(STDOUT)
+  c.logger.level = Logger::INFO
+end
+
+if defined?(Rails)
+  if defined?(Rails::Railtie)
+    require 'qu/railtie'
+  else
+    Qu.logger = Rails.logger
+  end
+end
+

--- a/lib/qu.rb
+++ b/lib/qu.rb
@@ -29,17 +29,3 @@ module Qu
     backend.enqueue Payload.new(:klass => klass, :args => args)
   end
 end
-
-Qu.configure do |c|
-  c.logger = Logger.new(STDOUT)
-  c.logger.level = Logger::INFO
-end
-
-if defined?(Rails)
-  if defined?(Rails::Railtie)
-    require 'qu/railtie'
-  else
-    Qu.logger = Rails.logger
-  end
-end
-

--- a/lib/qu/version.rb
+++ b/lib/qu/version.rb
@@ -1,3 +1,3 @@
 module Qu
-  VERSION = "0.1.4"
+  VERSION = "1.0.0"
 end

--- a/qu-rails.gemspec
+++ b/qu-rails.gemspec
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require "qu/version"
+
+Gem::Specification.new do |s|
+  s.name        = "qu-rails"
+  s.version     = Qu::VERSION
+  s.authors     = ["Brandon Keepers"]
+  s.email       = ["brandon@opensoul.org"]
+  s.homepage    = "http://github.com/bkeepers/qu"
+  s.summary     = "Rails hooks for qu"
+  s.description = "Rials hooks for qu"
+
+  s.files         = `git ls-files -- lib | grep rails`.split("\n")
+  s.require_paths = ["lib"]
+
+  s.add_dependency 'qu', Qu::VERSION
+  s.add_development_dependency 'bson_ext'
+end


### PR DESCRIPTION
This moves rails code into qu-rails.rb and has a gemspec for it. I bumped the version to v1.0.0. You can change it to something else, but with the deprecation warning in #46 Qu seems to be committing to a public API.

If Qu stays v0.x.x, I wouldn't worry about communicating API changes to the user via deprecation warnings or maintaining backwards compatibility.
