### PR TITLE
Add mongolab configuration to mongo backend

### DIFF
--- a/lib/qu/backend/mongo.rb
+++ b/lib/qu/backend/mongo.rb
@@ -21,7 +21,8 @@ module Qu
 
       def connection
         @connection ||= begin
-          uri = URI.parse(ENV['MONGOHQ_URL'].to_s)
+          host_uri = (ENV['MONGOHQ_URL'] || ENV['MONGOLAB_URI']).to_s
+          uri = URI.parse(host_uri)
           database = uri.path.empty? ? 'qu' : uri.path[1..-1]
           options = {}
           if uri.password


### PR DESCRIPTION
Hello,

qu could connect to mongo hq databases on heroku automatically already. I have added a single line to make the same possible with mongolab, another provider of the same service on heroku. 
Would be nice if you could pull this into the main version, so that I can drop my fork again.

Best regards, Björn
