### PR TITLE
Mongoid 3 (Moped) backend

### DIFF
--- a/lib/qu-mongoid.rb
+++ b/lib/qu-mongoid.rb
@@ -1,0 +1,4 @@
+require 'qu'
+require 'qu/backend/mongoid'
+
+Qu.backend = Qu::Backend::Mongoid.new

--- a/lib/qu/backend/mongoid.rb
+++ b/lib/qu/backend/mongoid.rb
@@ -1,0 +1,131 @@
+require 'mongoid'
+
+module Qu
+  module Backend
+    class Mongoid < Base
+
+      # Number of times to retry connection on connection failure (default: 5)
+      attr_accessor :max_retries
+
+      # Seconds to wait before try to reconnect after connection failure (default: 1)
+      attr_accessor :retry_frequency
+
+      # Seconds to wait before looking for more jobs when the queue is empty (default: 5)
+      attr_accessor :poll_frequency
+
+      def initialize
+        self.max_retries     = 5
+        self.retry_frequency = 1
+        self.poll_frequency  = 5
+      end
+
+      def connection
+        @connection ||= begin
+          unless ::Mongoid.sessions[:default]
+            if (uri = (ENV['MONGOHQ_URL'] || ENV['MONGOLAB_URI']).to_s) && !uri.empty?
+              ::Mongoid.sessions = {:default => {:uri => uri, :max_retries_on_connection_failure => 4}}
+            else
+              ::Mongoid.connect_to('qu')
+            end
+          end
+          ::Mongoid::Sessions.default
+        end
+      end
+      alias_method :database, :connection
+
+      def clear(queue = nil)
+        queue ||= queues + ['failed']
+        logger.info { "Clearing queues: #{queue.inspect}" }
+        Array(queue).each do |q|
+          logger.debug "Clearing queue #{q}"
+          jobs(q).drop
+          self[:queues].where({:name => q}).remove
+        end
+      end
+
+      def queues
+        self[:queues].find.map {|doc| doc['name'] }
+      end
+
+      def length(queue = 'default')
+        jobs(queue).find.count
+      end
+
+      def enqueue(payload)
+        payload.id = ::Moped::BSON::ObjectId.new
+        jobs(payload.queue).insert({:_id => payload.id, :klass => payload.klass.to_s, :args => payload.args})
+        self[:queues].where({:name => payload.queue}).upsert({:name => payload.queue})
+        logger.debug { "Enqueued job #{payload}" }
+        payload
+      end
+
+      def reserve(worker, options = {:block => true})
+        loop do
+          worker.queues.each do |queue|
+            logger.debug { "Reserving job in queue #{queue}" }
+
+            begin
+              doc = connection.command(:findAndModify => jobs(queue).name, :remove => true)
+              if doc && doc['value']
+                doc = doc['value']
+                doc['id'] = doc.delete('_id')
+                return Payload.new(doc)
+              end
+            rescue ::Moped::Errors::OperationFailure
+              # No jobs in the queue (MongoDB <2)
+            end
+          end
+
+          if options[:block]
+            sleep poll_frequency
+          else
+            break
+          end
+        end
+      end
+
+      def release(payload)
+        jobs(payload.queue).insert({:_id => payload.id, :klass => payload.klass.to_s, :args => payload.args})
+      end
+
+      def failed(payload, error)
+        jobs('failed').insert(:_id => payload.id, :klass => payload.klass.to_s, :args => payload.args, :queue => payload.queue)
+      end
+
+      def completed(payload)
+      end
+
+      def register_worker(worker)
+        logger.debug "Registering worker #{worker.id}"
+        self[:workers].insert(worker.attributes.merge(:id => worker.id))
+      end
+
+      def unregister_worker(worker)
+        logger.debug "Unregistering worker #{worker.id}"
+        self[:workers].where(:id => worker.id).remove
+      end
+
+      def workers
+        self[:workers].find.map do |doc|
+          Qu::Worker.new(doc)
+        end
+      end
+
+      def clear_workers
+        logger.info "Clearing workers"
+        self[:workers].drop
+      end
+
+    private
+
+      def jobs(queue)
+        self["queue:#{queue}"]
+      end
+
+      def [](name)
+        database["qu:#{name}"]
+      end
+
+    end
+  end
+end

--- a/qu-mongoid.gemspec
+++ b/qu-mongoid.gemspec
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require "qu/version"
+
+Gem::Specification.new do |s|
+  s.name        = "qu-mongoid"
+  s.version     = Qu::VERSION
+  s.authors     = ["Brandon Keepers"]
+  s.email       = ["brandon@opensoul.org"]
+  s.homepage    = "http://github.com/bkeepers/qu"
+  s.summary     = "Mongoid backend for qu"
+  s.description = "Mongoid backend for qu"
+
+  s.files         = `git ls-files -- lib | grep mongoid`.split("\n")
+  s.require_paths = ["lib"]
+
+  s.add_dependency 'mongoid'
+  s.add_dependency 'qu', Qu::VERSION
+end

--- a/spec/qu/backend/mongoid_spec.rb
+++ b/spec/qu/backend/mongoid_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'qu-mongoid'
+require 'thread'
+
+describe Qu::Backend::Mongoid do
+  it_should_behave_like 'a backend'
+
+  describe 'connection' do
+    it 'should default the qu database' do
+      subject.connection.should be_instance_of(Moped::Session)
+      subject.connection.options[:database].should == 'qu'
+    end
+    
+    it 'should use MONGOHQ_URL from heroku' do
+      # Clean up from other tests
+      ::Mongoid.sessions[:default]  = nil
+      subject.instance_eval {@connection=nil}
+      ::Mongoid::Sessions.clear
+      
+      ENV['MONGOHQ_URL'] = 'mongodb://127.0.0.1:27017/quspec'
+      subject.connection.options[:database].should == 'quspec'
+      subject.connection.cluster.nodes.first.resolved_address.should == "127.0.0.1:27017"
+      ::Mongoid.sessions[:default][:hosts].should include("127.0.0.1:27017")
+      
+      # Clean up MONGOHQ stuff
+      ENV.delete('MONGOHQ_URL')
+      subject.instance_eval {@connection=nil}
+      ::Mongoid.connect_to('qu')
+    end
+  end
+
+  describe 'reserve' do
+    let(:worker) { Qu::Worker.new }
+
+    describe "on mongo >=2" do
+      it 'should return nil when no jobs exist' do
+        subject.clear
+        Moped::Session.any_instance.should_receive(:command).and_return(nil)
+        lambda { subject.reserve(worker, :block => false).should be_nil }.should_not raise_error
+      end
+    end
+
+    describe 'on mongo <2' do
+      it 'should return nil when no jobs exist' do
+        subject.clear
+        Moped::Session.any_instance.should_receive(:command).and_raise(Moped::Errors::OperationFailure.new(nil, 'test'))
+        lambda { subject.reserve(worker, :block => false).should be_nil }.should_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
I was excited to find a queue/worker gem that supported mongoDB as a backend!

The current implementation uses the 10gen mongo driver, which works beautifully with MongoMapper and Mongoid 2. However, Mongoid 3 has implemented its own mongoDB driver, Moped.

To avoid having two different drivers loaded in my app, I ported the mongo driver over to use Mongoid's Moped driver. It is a separate gem/backend: qu-mongoid.

Thanks again for the awesome gem!
