### PR TITLE
Graceful shutdown

### DIFF
--- a/lib/qu.rb
+++ b/lib/qu.rb
@@ -13,7 +13,7 @@ module Qu
   extend SingleForwardable
   extend self
 
-  attr_accessor :backend, :failure, :logger
+  attr_accessor :backend, :failure, :logger, :graceful_shutdown
 
   def_delegators :backend, :length, :queues, :reserve, :clear, :connection=
 

--- a/lib/qu/tasks.rb
+++ b/lib/qu/tasks.rb
@@ -2,7 +2,12 @@ namespace :qu do
   desc "Start a worker"
   task :work  => :environment do
     queues = (ENV['QUEUES'] || ENV['QUEUE'] || 'default').to_s.split(',')
-    Qu::Worker.new(*queues).start
+    worker = Qu::Worker.new(*queues)
+    begin
+      worker.start
+    rescue Qu::Worker::Abort
+      Qu.logger.debug "Worker #{worker.id} aborted"
+    end
   end
 end
 

--- a/lib/qu/tasks.rb
+++ b/lib/qu/tasks.rb
@@ -5,8 +5,11 @@ namespace :qu do
     worker = Qu::Worker.new(*queues)
     begin
       worker.start
+    rescue Qu::Worker::Stop
+      Qu.logger.debug "Worker #{worker.id} stopped"
     rescue Qu::Worker::Abort
       Qu.logger.debug "Worker #{worker.id} aborted"
+      exit(1)
     end
   end
 end

--- a/spec/qu/worker_spec.rb
+++ b/spec/qu/worker_spec.rb
@@ -43,15 +43,50 @@ describe Qu::Worker do
       Qu.backend.should_receive(:register_worker).with(subject)
       subject.start
     end
-
+  end
+  
+  describe 'stop' do
+    before do
+      job.stub(:perform) do
+        Process.kill('SIGTERM', $$)
+        sleep(0.01)
+      end
+      Qu.stub!(:reserve).and_return(job)
+    end
+    
     context 'when aborting' do
       before do
-        subject.stub(:loop).and_raise(Qu::Worker::Abort)
+        Qu.graceful_shutdown = false
       end
 
       it 'should unregister worker' do
         Qu.backend.should_receive(:unregister_worker).with(subject)
+        
+        expect { subject.start }.to raise_exception(Qu::Worker::Abort)
+      end
+    end
+    
+    context 'when stopping' do
+      before do
+        Qu.graceful_shutdown = true
+      end
+      
+      it 'should wait for the job to finish, shut down gracefully, and unregister worker' do
+        Qu.backend.should_receive(:unregister_worker).with(subject)
+        
         subject.start
+      end
+      
+      it 'should abort if the worker is blocked waiting for a new job' do
+        Qu.backend.should_receive(:unregister_worker).with(subject)
+        Qu.stub(:reserve) { sleep }
+        
+        t = Thread.new do
+          sleep(0.01)
+          Process.kill('SIGTERM', $$)
+        end
+        
+        expect { subject.start }.to raise_exception(Qu::Worker::Abort)
       end
     end
   end

--- a/spec/qu/worker_spec.rb
+++ b/spec/qu/worker_spec.rb
@@ -67,17 +67,15 @@ describe Qu::Worker do
     end
     
     context 'when stopping' do
-      before do
-        Qu.graceful_shutdown = true
-      end
-      
       it 'should wait for the job to finish, shut down gracefully, and unregister worker' do
+        Qu.graceful_shutdown = true
+        
         Qu.backend.should_receive(:unregister_worker).with(subject)
         
         subject.start
       end
       
-      it 'should abort if the worker is blocked waiting for a new job' do
+      it 'should stop if the worker is blocked waiting for a new job' do
         Qu.backend.should_receive(:unregister_worker).with(subject)
         Qu.stub(:reserve) { sleep }
         
@@ -86,7 +84,7 @@ describe Qu::Worker do
           Process.kill('SIGTERM', $$)
         end
         
-        expect { subject.start }.to raise_exception(Qu::Worker::Abort)
+        expect { subject.start }.to raise_exception(Qu::Worker::Stop)
       end
     end
   end


### PR DESCRIPTION
This pull request implements graceful shutdown for Qu workers. I needed to make the change because when a worker aborts, it sometimes wouldn't be able to re-queue the job into the failure queue due to the Mongoid connection already being closed. So jobs would mysteriously go missing.

Features:
- Optional via configuration: `Qu.graceful_shutdown = true`
- If the worker is performing a job, waits for the job to complete before shutting down.
- If the worker is blocked waiting for new jobs, Abort is raised instead to force an exit.
- Specs!
