### PR TITLE
Fix for issue 64 and mongo > 1.8.3

### DIFF
--- a/lib/qu/backend/mongo.rb
+++ b/lib/qu/backend/mongo.rb
@@ -27,9 +27,9 @@ module Qu
           options = {}
           if uri.password
             options[:auths] = [{
-              'db_name'  => database,
-              'username' => uri.user,
-              'password' => uri.password
+              :db_name  => database,
+              :username => uri.user,
+              :password => uri.password
             }]
           end
           ::Mongo::Connection.new(uri.host, uri.port, options).db(database)

--- a/lib/qu/backend/mongo.rb
+++ b/lib/qu/backend/mongo.rb
@@ -22,17 +22,13 @@ module Qu
       def connection
         @connection ||= begin
           host_uri = (ENV['MONGOHQ_URL'] || ENV['MONGOLAB_URI']).to_s
-          uri = URI.parse(host_uri)
-          database = uri.path.empty? ? 'qu' : uri.path[1..-1]
-          options = {}
-          if uri.password
-            options[:auths] = [{
-              :db_name  => database,
-              :username => uri.user,
-              :password => uri.password
-            }]
+          if host_uri && !host_uri.empty?
+            uri = URI.parse(host_uri)
+            database = uri.path.empty? ? 'qu' : uri.path[1..-1]
+            ::Mongo::MongoClient.from_uri(host_uri).db(database)
+          else
+            ::Mongo::MongoClient.new.db('qu')
           end
-          ::Mongo::Connection.new(uri.host, uri.port, options).db(database)
         end
       end
       alias_method :database, :connection

--- a/spec/qu/backend/mongo_spec.rb
+++ b/spec/qu/backend/mongo_spec.rb
@@ -19,8 +19,8 @@ describe Qu::Backend::Mongo do
       ENV['MONGOHQ_URL'] = 'mongodb://user:pw@host:10060/quspec'
       subject.connection.name.should == 'quspec'
       # debugger
-      subject.connection.connection.host_to_try.should == ['host', 10060]
-      subject.connection.connection.auths.should == [{'db_name' => 'quspec', 'username' => 'user', 'password' => 'pw'}]
+      subject.connection.connection.host_port.should == ['host', 10060]
+      subject.connection.connection.auths.should == [{:db_name => 'quspec', :username => 'user', :password => 'pw'}]
     end
 
     context "Connection Failure" do


### PR DESCRIPTION
Seems like some changes in mongo 1.8.4 broke qu-mongo backend as noted in issue #64. This pull request fixes the issue. I tested mongo 1.8.6 and 1.8.3 and the changeset works for both and all the tests pass on both.
