### PR TITLE
AWS-ome backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
+  - 2.0.0
 services:
   - mongodb
   - redis
+script: bundle exec rake unattended_spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ services:
   - mongodb
   - redis
 script: bundle exec rake unattended_spec
+cache: bundler

--- a/Rakefile
+++ b/Rakefile
@@ -48,3 +48,45 @@ def changelog
 end
 
 task :default => :spec
+
+desc "Start fake services, run tests, cleanup"
+task :unattended_spec do |t|
+  require 'tmpdir'
+  require 'socket'
+
+  dir = Dir.mktmpdir
+  data_file = File.join(dir, "data.fdb")
+
+  sqs_pid = Process.spawn 'fake_sqs', '-p', '5111', err: '/dev/null', out: '/dev/null'
+  dynamo_pid = Process.spawn 'fake_dynamo', '-d', data_file, '-p', '5112', err: '/dev/null', out: '/dev/null'
+
+  at_exit {
+    Process.kill('TERM', sqs_pid)
+    Process.kill('TERM', dynamo_pid)
+    FileUtils.rmtree(dir)
+  }
+
+  40.downto(0) do |count|
+    begin
+      s = TCPSocket.new 'localhost', 5112
+      s.close
+      break
+    rescue Errno::ECONNREFUSED
+      raise if count == 0
+      sleep 0.1
+    end
+  end
+
+  40.downto(0) do |count|
+    begin
+      s = TCPSocket.new 'localhost', 5111
+      s.close
+      break
+    rescue Errno::ECONNREFUSED
+      raise if count == 0
+      sleep 0.1
+    end
+  end
+
+  Rake::Task["spec"].invoke
+end

--- a/lib/qu-aws.rb
+++ b/lib/qu-aws.rb
@@ -1,0 +1,4 @@
+require 'qu'
+require 'qu/backend/aws'
+
+Qu.backend = Qu::Backend::AWS.new

--- a/lib/qu.rb
+++ b/lib/qu.rb
@@ -3,13 +3,12 @@ require 'qu/logger'
 require 'qu/failure'
 require 'qu/payload'
 require 'qu/backend/base'
+require 'qu/worker'
 
 require 'forwardable'
 require 'logger'
 
 module Qu
-  autoload :Worker, 'qu/worker'
-
   extend SingleForwardable
   extend self
 
@@ -34,4 +33,3 @@ Qu.configure do |c|
   c.logger = Logger.new(STDOUT)
   c.logger.level = Logger::INFO
 end
-

--- a/lib/qu/backend/aws.rb
+++ b/lib/qu/backend/aws.rb
@@ -1,0 +1,107 @@
+require 'digest/sha1'
+
+module Qu
+  module Backend
+    class AWS < Base
+      # Seconds to wait before looking for more jobs when the queue is empty (default: 5)
+      attr_accessor :poll_frequency
+
+      def initialize
+        self.poll_frequency  = 5
+      end
+
+      def enqueue(payload)
+        # id does not really matter for aws as they have ids already so i'm just
+        # sending something relatively unique for errors and what not
+        payload.id = Digest::SHA1.hexdigest(payload.to_s + Time.now.to_s)
+
+        connection.enqueue(payload.queue, encode(payload.attributes))
+        connection.register_queue(payload.queue)
+
+        logger.debug { "Enqueued job #{payload}" }
+        payload
+      end
+
+      def completed(payload)
+        payload.message.delete
+      end
+
+      def release(payload)
+        payload.message.delete
+        connection.enqueue(payload.queue, encode(payload.attributes))
+      end
+
+      def failed(payload, error)
+        attrs = payload.attributes.merge(:queue => payload.queue)
+        connection.enqueue('failed', encode(attrs))
+      end
+
+      def reserve(worker, options = {:block => true})
+        loop do
+          worker.queues.each do |queue_name|
+            logger.debug { "Reserving job in queue #{queue_name}" }
+
+            if message = connection.dequeue(queue_name)
+              doc = decode(message.body)
+              payload = Payload.new(doc)
+              payload.message = message
+              return payload
+            end
+          end
+
+          if options[:block]
+            sleep poll_frequency
+          else
+            break
+          end
+        end
+      end
+
+      def length(queue_name = 'default')
+        connection.depth(queue_name)
+      end
+
+      def clear(queue_name = nil)
+        if queue_name.nil?
+          (queues + ['failed']).each do |name|
+            connection.drain(name)
+            connection.unregister_queue(name)
+          end
+        else
+          connection.drain(queue_name)
+          connection.unregister_queue(queue_name)
+        end
+      end
+
+      def queues
+        connection.queues
+      end
+
+      def register_worker(worker)
+        connection.register_worker(worker)
+      end
+
+      def unregister_worker(worker)
+        connection.unregister_worker(worker)
+      end
+
+      def workers
+        connection.workers
+      end
+
+      def clear_workers
+        connection.clear_workers(workers)
+      end
+
+      def connection
+        @connection ||= AWS::Connection.new
+      end
+
+      def connection=(new_connection)
+        @connection = new_connection
+      end
+    end
+  end
+end
+
+require 'qu/backend/aws/connection'

--- a/lib/qu/backend/aws/connection.rb
+++ b/lib/qu/backend/aws/connection.rb
@@ -1,0 +1,83 @@
+require 'qu/backend/aws/sns/publisher'
+require 'qu/backend/aws/sqs/publisher'
+require 'qu/backend/aws/sqs/subscriber'
+require 'qu/backend/aws/dynamo/state'
+
+module Qu
+  module Backend
+    class AWS
+      class Connection
+        # Private
+        attr_reader :publisher
+
+        # Private
+        attr_reader :subscriber
+
+        # Private
+        attr_reader :worker_state
+
+        # Private
+        attr_reader :queue_state
+
+        def initialize(options = {})
+          @publisher = options.fetch(:publisher) { AWS::SQS::Publisher.new }
+          @subscriber = options.fetch(:subscriber) { AWS::SQS::Subscriber.new }
+          @worker_state = options.fetch(:worker_state) { Dynamo::State.new("workers") }
+          @queue_state = options.fetch(:queue_state) { Dynamo::State.new("queues") }
+        end
+
+        def enqueue(queue_name, body)
+          publisher.publish(queue_name, body)
+        end
+
+        def dequeue(queue_name)
+          subscriber.receive(queue_name)
+        end
+
+        def depth(queue_name)
+          subscriber.depth(queue_name)
+        end
+
+        def drain(queue_name)
+          subscriber.drain(queue_name)
+        end
+
+        def queues
+          queue_state.map { |doc| doc[:id] }
+        end
+
+        def register_queue(queue_name)
+          queue_state.register(queue_name)
+        end
+
+        def unregister_queue(queue_name)
+          queue_state.unregister(queue_name)
+        end
+
+        def workers
+          worker_state.map { |doc|
+            hostname, pid, queues = doc[:id].split(':', 3)
+
+            Qu::Worker.new({
+              "hostname" => hostname,
+              "pid" => pid.to_i,
+              "queues" => queues.split(','),
+            })
+          }
+        end
+
+        def register_worker(worker)
+          worker_state.register(worker.id)
+        end
+
+        def unregister_worker(worker)
+          worker_state.unregister(worker.id)
+        end
+
+        def clear_workers(workers)
+          worker_state.unregister(workers.map(&:id))
+        end
+      end
+    end
+  end
+end

--- a/lib/qu/backend/aws/dynamo/state.rb
+++ b/lib/qu/backend/aws/dynamo/state.rb
@@ -1,0 +1,57 @@
+require 'aws/dynamo_db'
+
+module Qu
+  module Backend
+    class AWS
+      class Dynamo
+        class State
+          include Enumerable
+
+          # Private
+          def self.table
+            @table ||= begin
+              dynamo = ::AWS::DynamoDB.new
+              table = dynamo.tables[ENV.fetch("QU_DYNAMO_TABLE_NAME", "qu_gem")]
+              table.load_schema
+            end
+          end
+
+          # Private
+          attr_reader :namespace
+
+          # Private
+          attr_reader :table
+
+          def initialize(namespace, options = {})
+            @namespace = namespace
+            @table = options.fetch(:table) { self.class.table }
+          end
+
+          def each
+            table.items.query(:hash_value => namespace).each { |item|
+              yield({:id => item.range_value})
+            }
+          end
+
+          def register(id)
+            doc = {
+              :namespace => namespace,
+              :id => id,
+              :created_at => Time.now.to_i,
+            }
+            options = {
+              :unless_exists => [namespace,  id],
+            }
+            table.items.put(doc, options)
+          end
+
+          def unregister(*ids)
+            ids = Array(ids).flatten
+            namespaced_ids = ids.map { |id| [namespace, id] }
+            table.batch_write(:delete => namespaced_ids)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/qu/backend/aws/sns/client.rb
+++ b/lib/qu/backend/aws/sns/client.rb
@@ -1,0 +1,18 @@
+require 'aws/sns'
+
+module Qu
+  module Backend
+    class AWS
+      class SNS
+        class Client
+          # Private
+          attr_reader :sns
+
+          def initialize(options = {})
+            @sns = options.fetch(:sns) { ::AWS::SNS.new }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/qu/backend/aws/sns/publisher.rb
+++ b/lib/qu/backend/aws/sns/publisher.rb
@@ -1,0 +1,15 @@
+require 'qu/backend/aws/sns/client'
+
+module Qu
+  module Backend
+    class AWS
+      class SNS
+        class Publisher < Client
+          def publish(topic_name, body)
+            sns.publish(topic_name, body)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/qu/backend/aws/sqs/client.rb
+++ b/lib/qu/backend/aws/sqs/client.rb
@@ -1,0 +1,18 @@
+require 'aws/sqs'
+
+module Qu
+  module Backend
+    class AWS
+      class SQS
+        class Client
+          # Private
+          attr_reader :sqs
+
+          def initialize(options = {})
+            @sqs = options.fetch(:sqs) { ::AWS::SQS.new }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/qu/backend/aws/sqs/publisher.rb
+++ b/lib/qu/backend/aws/sqs/publisher.rb
@@ -1,0 +1,21 @@
+require 'qu/backend/aws/sqs/client'
+
+module Qu
+  module Backend
+    class AWS
+      class SQS
+        class Publisher < Client
+          def publish(queue_name, body)
+            queue = begin
+              sqs.queues.named(queue_name)
+            rescue ::AWS::SQS::Errors::NonExistentQueue
+              sqs.queues.create(queue_name)
+            end
+
+            queue.send_message(body)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/qu/backend/aws/sqs/subscriber.rb
+++ b/lib/qu/backend/aws/sqs/subscriber.rb
@@ -1,0 +1,43 @@
+require 'qu/backend/aws/sqs/client'
+
+module Qu
+  module Backend
+    class AWS
+      class SQS
+        class Subscriber < Client
+          def receive(queue_name)
+            begin
+              queue = sqs.queues.named(queue_name)
+              queue.receive_message
+            rescue ::AWS::SQS::Errors::NonExistentQueue
+            end
+          end
+
+          def depth(queue_name)
+            begin
+              sqs.queues.named(queue_name).visible_messages
+            rescue ::AWS::SQS::Errors::NonExistentQueue
+              0
+            end
+          end
+
+          def drain(queue_name)
+            begin
+              queue = sqs.queues.named(queue_name)
+              messages = []
+              begin
+                begin
+                  messages = queue.receive_message(:limit => 10)
+                  queue.batch_delete(messages)
+                rescue ::AWS::SQS::Errors::BatchDeleteSend
+                end
+              end while messages.size > 0
+            rescue ::AWS::SQS::Errors::NonExistentQueue
+              # doesn't exist so no need to flush
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/qu/backend/spec.rb
+++ b/lib/qu/backend/spec.rb
@@ -12,240 +12,252 @@ class CustomQueue
   @queue = :custom
 end
 
-shared_examples_for 'a backend' do
-  let(:worker) { Qu::Worker.new('default') }
-  let(:payload) { Qu::Payload.new(:klass => SimpleJob) }
+shared_examples_for 'a backend' do |options|
+  options ||= {}
+  services = Array(options[:services]).inject({}) { |hash, service|
+    hash[service] = service_running?(service)
+    hash
+  }
 
-  before(:all) do
-    Qu.backend = described_class.new
-  end
+  down_services = services.select { |k, v| !v }.keys
 
-  before do
-    subject.clear
-    subject.clear_workers
-  end
+  if down_services.empty?
+    let(:worker) { Qu::Worker.new('default') }
+    let(:payload) { Qu::Payload.new(:klass => SimpleJob) }
 
-  describe 'enqueue' do
-    it 'should return a payload' do
-      subject.enqueue(payload).should be_instance_of(Qu::Payload)
+    before(:all) do
+      Qu.backend = described_class.new
     end
 
-    it 'should set the payload id' do
-      subject.enqueue(payload)
-      payload.id.should_not be_nil
-    end
-
-    it 'should add a job to the queue' do
-      subject.enqueue(payload)
-      payload.queue.should == 'default'
-      subject.length(payload.queue).should == 1
-    end
-
-    it 'should add queue to list of queues' do
-      subject.queues.should == []
-      subject.enqueue(payload)
-      subject.queues.should == [payload.queue]
-    end
-
-    it 'should assign a different job id for the same job enqueue multiple times' do
-      subject.enqueue(payload).id.should_not == subject.enqueue(payload).id
-    end
-  end
-
-  describe 'length' do
-    it 'should use the default queue by default' do
-      subject.length.should == 0
-      subject.enqueue(payload)
-      subject.length.should == 1
-    end
-  end
-
-  describe 'clear' do
-    it 'should clear jobs for given queue' do
-      subject.enqueue payload
-      subject.length(payload.queue).should == 1
-      subject.clear(payload.queue)
-      subject.length(payload.queue).should == 0
-      subject.queues.should_not include(payload.queue)
-    end
-
-    it 'should not clear jobs for a different queue' do
-      subject.enqueue(payload)
-      subject.clear('other')
-      subject.length(payload.queue).should == 1
-    end
-
-    it 'should clear all queues without any args' do
-      subject.enqueue(payload).queue.should == 'default'
-      subject.enqueue(Qu::Payload.new(:klass => CustomQueue)).queue.should == 'custom'
-      subject.length('default').should == 1
-      subject.length('custom').should == 1
-      subject.clear
-      subject.length('default').should == 0
-      subject.length('custom').should == 0
-    end
-
-    it 'should clear failed queue without any args' do
-      subject.enqueue(payload)
-      subject.failed(payload, Exception.new)
-      subject.length('failed').should == 1
-      subject.clear
-      subject.length('failed').should == 0
-    end
-
-    it 'should not clear failed queue with specified queues' do
-      subject.enqueue(payload)
-      subject.failed(payload, Exception.new)
-      subject.length('failed').should == 1
-      subject.clear('default')
-      subject.length('failed').should == 1
-    end
-  end
-
-  describe 'reserve' do
     before do
-      subject.enqueue(payload)
-    end
-
-    it 'should return next job' do
-      subject.reserve(worker).id.should == payload.id
-    end
-
-    it 'should not return an already reserved job' do
-      subject.enqueue(payload.dup)
-      subject.reserve(worker).id.should_not == subject.reserve(worker).id
-    end
-
-    it 'should return next job in given queues' do
-      subject.enqueue(payload.dup)
-      custom = subject.enqueue(Qu::Payload.new(:klass => CustomQueue))
-      subject.enqueue(payload.dup)
-
-      worker = Qu::Worker.new('custom', 'default')
-
-      subject.reserve(worker).id.should == custom.id
-    end
-
-    it 'should not return job from different queue' do
-      worker = Qu::Worker.new('video')
-      timeout { subject.reserve(worker) }.should be_nil
-    end
-
-    it 'should block by default if no jobs available' do
       subject.clear
-      timeout(1) do
-        subject.reserve(worker)
-        fail("#reserve should block")
+      subject.clear_workers
+    end
+
+    describe 'enqueue' do
+      it 'should return a payload' do
+        subject.enqueue(payload).should be_instance_of(Qu::Payload)
+      end
+
+      it 'should set the payload id' do
+        subject.enqueue(payload)
+        payload.id.should_not be_nil
+      end
+
+      it 'should add a job to the queue' do
+        subject.enqueue(payload)
+        payload.queue.should == 'default'
+        subject.length(payload.queue).should == 1
+      end
+
+      it 'should add queue to list of queues' do
+        subject.queues.should == []
+        subject.enqueue(payload)
+        subject.queues.should == [payload.queue]
+      end
+
+      it 'should assign a different job id for the same job enqueue multiple times' do
+        subject.enqueue(payload).id.should_not == subject.enqueue(payload).id
       end
     end
 
-    it 'should not block if :block option is set to false' do
-      timeout(1) do
-        subject.reserve(worker, :block => false)
-        true
-      end.should be_true
+    describe 'length' do
+      it 'should use the default queue by default' do
+        subject.length.should == 0
+        subject.enqueue(payload)
+        subject.length.should == 1
+      end
     end
 
-    it 'should properly persist args' do
-      subject.clear
-      payload.args = ['a', 'b']
-      subject.enqueue(payload)
-      subject.reserve(worker).args.should == ['a', 'b']
+    describe 'clear' do
+      it 'should clear jobs for given queue' do
+        subject.enqueue payload
+        subject.length(payload.queue).should == 1
+        subject.clear(payload.queue)
+        subject.length(payload.queue).should == 0
+        subject.queues.should_not include(payload.queue)
+      end
+
+      it 'should not clear jobs for a different queue' do
+        subject.enqueue(payload)
+        subject.clear('other')
+        subject.length(payload.queue).should == 1
+      end
+
+      it 'should clear all queues without any args' do
+        subject.enqueue(payload).queue.should == 'default'
+        subject.enqueue(Qu::Payload.new(:klass => CustomQueue)).queue.should == 'custom'
+        subject.length('default').should == 1
+        subject.length('custom').should == 1
+        subject.clear
+        subject.length('default').should == 0
+        subject.length('custom').should == 0
+      end
+
+      it 'should clear failed queue without any args' do
+        subject.enqueue(payload)
+        subject.failed(payload, Exception.new)
+        subject.length('failed').should == 1
+        subject.clear
+        subject.length('failed').should == 0
+      end
+
+      it 'should not clear failed queue with specified queues' do
+        subject.enqueue(payload)
+        subject.failed(payload, Exception.new)
+        subject.length('failed').should == 1
+        subject.clear('default')
+        subject.length('failed').should == 1
+      end
     end
 
-    it 'should properly persist a hash argument' do
-      subject.clear
-      payload.args = [{:a => 1, :b => 2}]
-      subject.enqueue(payload)
-      subject.reserve(worker).args.should == [{'a' => 1, 'b' => 2}]
+    describe 'reserve' do
+      before do
+        subject.enqueue(payload)
+      end
+
+      it 'should return next job' do
+        subject.reserve(worker).id.should == payload.id
+      end
+
+      it 'should not return an already reserved job' do
+        subject.enqueue(payload.dup)
+        subject.reserve(worker).id.should_not == subject.reserve(worker).id
+      end
+
+      it 'should return next job in given queues' do
+        subject.enqueue(payload.dup)
+        custom = subject.enqueue(Qu::Payload.new(:klass => CustomQueue))
+        subject.enqueue(payload.dup)
+
+        worker = Qu::Worker.new('custom', 'default')
+
+        subject.reserve(worker).id.should == custom.id
+      end
+
+      it 'should not return job from different queue' do
+        worker = Qu::Worker.new('video')
+        timeout { subject.reserve(worker) }.should be_nil
+      end
+
+      it 'should block by default if no jobs available' do
+        subject.clear
+        timeout(1) do
+          subject.reserve(worker)
+          fail("#reserve should block")
+        end
+      end
+
+      it 'should not block if :block option is set to false' do
+        timeout(1) do
+          subject.reserve(worker, :block => false)
+          true
+        end.should be_true
+      end
+
+      it 'should properly persist args' do
+        subject.clear
+        payload.args = ['a', 'b']
+        subject.enqueue(payload)
+        subject.reserve(worker).args.should == ['a', 'b']
+      end
+
+      it 'should properly persist a hash argument' do
+        subject.clear
+        payload.args = [{:a => 1, :b => 2}]
+        subject.enqueue(payload)
+        subject.reserve(worker).args.should == [{'a' => 1, 'b' => 2}]
+      end
+
+      def timeout(count = 0.1, &block)
+        SystemTimer.timeout(count, &block)
+      rescue Timeout::Error
+        nil
+      end
     end
 
-    def timeout(count = 0.1, &block)
-      SystemTimer.timeout(count, &block)
-    rescue Timeout::Error
-      nil
-    end
-  end
+    describe 'failed' do
+      let(:payload) { Qu::Payload.new(:id => '1', :klass => SimpleJob) }
 
-  describe 'failed' do
-    let(:payload) { Qu::Payload.new(:id => '1', :klass => SimpleJob) }
+      it 'should add to failure queue' do
+        subject.failed(payload, Exception.new)
+        subject.length('failed').should == 1
+      end
 
-    it 'should add to failure queue' do
-      subject.failed(payload, Exception.new)
-      subject.length('failed').should == 1
-    end
-
-    it 'should not add failed queue to the list of queues' do
-      subject.failed(payload, Exception.new)
-      subject.queues.should_not include('failed')
-    end
-  end
-
-  describe 'completed' do
-    it 'should be defined' do
-      subject.respond_to?(:completed).should be_true
-    end
-  end
-
-  describe 'release' do
-    before do
-      subject.enqueue(payload)
+      it 'should not add failed queue to the list of queues' do
+        subject.failed(payload, Exception.new)
+        subject.queues.should_not include('failed')
+      end
     end
 
-    it 'should add the job back on the queue' do
-      reserved_payload = subject.reserve(worker)
-      reserved_payload.id.should == payload.id
-      subject.length(payload.queue).should == 0
-      subject.release(reserved_payload)
-      subject.length(payload.queue).should == 1
-    end
-  end
-
-  describe 'register_worker' do
-    it 'should add worker to array of workers' do
-      subject.register_worker(worker)
-      subject.workers.size.should == 1
-      subject.workers.first.attributes.should == worker.attributes
-    end
-  end
-
-  describe 'clear_workers' do
-    before { subject.register_worker Qu::Worker.new('default') }
-
-    it 'should remove workers' do
-      subject.workers.size.should == 1
-      subject.clear_workers
-      subject.workers.size.should == 0
-    end
-  end
-
-  describe 'unregister_worker' do
-    before { subject.register_worker(worker) }
-
-    it 'should remove worker' do
-      subject.unregister_worker(worker)
-      subject.workers.size.should == 0
+    describe 'completed' do
+      it 'should be defined' do
+        subject.respond_to?(:completed).should be_true
+      end
     end
 
-    it 'should not remove other workers' do
-      other_worker = Qu::Worker.new('other')
-      subject.register_worker(other_worker)
-      subject.workers.size.should == 2
-      subject.unregister_worker(other_worker)
-      subject.workers.size.should == 1
-      subject.workers.first.id.should == worker.id
-    end
-  end
+    describe 'release' do
+      before do
+        subject.enqueue(payload)
+      end
 
-  describe 'connection=' do
-    it 'should allow setting the connection' do
-      connection = mock('a connection')
-      subject.connection = connection
-      subject.connection.should == connection
+      it 'should add the job back on the queue' do
+        reserved_payload = subject.reserve(worker)
+        reserved_payload.id.should == payload.id
+        subject.length(payload.queue).should == 0
+        subject.release(reserved_payload)
+        subject.length(payload.queue).should == 1
+      end
     end
 
-    it 'should provide a default connection' do
-      subject.connection.should_not be_nil
+    describe 'register_worker' do
+      it 'should add worker to array of workers' do
+        subject.register_worker(worker)
+        subject.workers.size.should == 1
+        subject.workers.first.attributes.should == worker.attributes
+      end
     end
+
+    describe 'clear_workers' do
+      before { subject.register_worker Qu::Worker.new('default') }
+
+      it 'should remove workers' do
+        subject.workers.size.should == 1
+        subject.clear_workers
+        subject.workers.size.should == 0
+      end
+    end
+
+    describe 'unregister_worker' do
+      before { subject.register_worker(worker) }
+
+      it 'should remove worker' do
+        subject.unregister_worker(worker)
+        subject.workers.size.should == 0
+      end
+
+      it 'should not remove other workers' do
+        other_worker = Qu::Worker.new('other')
+        subject.register_worker(other_worker)
+        subject.workers.size.should == 2
+        subject.unregister_worker(other_worker)
+        subject.workers.size.should == 1
+        subject.workers.first.id.should == worker.id
+      end
+    end
+
+    describe 'connection=' do
+      it 'should allow setting the connection' do
+        connection = mock('a connection')
+        subject.connection = connection
+        subject.connection.should == connection
+      end
+
+      it 'should provide a default connection' do
+        subject.connection.should_not be_nil
+      end
+    end
+  else
+    puts "Skipping #{described_class}. Required services are not running (#{down_services.join(', ')})."
   end
 end

--- a/lib/qu/backend/spec.rb
+++ b/lib/qu/backend/spec.rb
@@ -248,7 +248,7 @@ shared_examples_for 'a backend' do |options|
 
     describe 'connection=' do
       it 'should allow setting the connection' do
-        connection = mock('a connection')
+        connection = double('a connection')
         subject.connection = connection
         subject.connection.should == connection
       end

--- a/lib/qu/backend/spec.rb
+++ b/lib/qu/backend/spec.rb
@@ -193,9 +193,10 @@ shared_examples_for 'a backend' do
     end
 
     it 'should add the job back on the queue' do
-      subject.reserve(worker).id.should == payload.id
+      reserved_payload = subject.reserve(worker)
+      reserved_payload.id.should == payload.id
       subject.length(payload.queue).should == 0
-      subject.release(payload)
+      subject.release(reserved_payload)
       subject.length(payload.queue).should == 1
     end
   end

--- a/lib/qu/payload.rb
+++ b/lib/qu/payload.rb
@@ -37,6 +37,14 @@ module Qu
       "#{id}:#{klass}:#{args.inspect}"
     end
 
+    def as_json(*)
+      {
+        :id => id,
+        :klass => klass.to_s,
+        :args => args,
+      }
+    end
+
   protected
 
     def constantize(class_name)

--- a/lib/qu/payload.rb
+++ b/lib/qu/payload.rb
@@ -37,7 +37,7 @@ module Qu
       "#{id}:#{klass}:#{args.inspect}"
     end
 
-    def as_json(*)
+    def attributes
       {
         :id => id,
         :klass => klass.to_s,

--- a/qu-aws.gemspec
+++ b/qu-aws.gemspec
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require "qu/version"
+
+Gem::Specification.new do |s|
+  s.name        = "qu-aws"
+  s.version     = Qu::VERSION
+  s.authors     = ["John Nunemaker"]
+  s.email       = ["nunemaker@gmail.com"]
+  s.homepage    = "http://github.com/bkeepers/qu"
+  s.summary     = "AWS backend for qu"
+  s.description = "AWS backend for qu"
+
+  s.files         = `git ls-files -- lib | grep aws`.split("\n")
+  s.require_paths = ["lib"]
+
+  s.add_dependency 'aws-sdk', '~> 1.0'
+  s.add_dependency 'qu', Qu::VERSION
+
+  s.add_development_dependency 'fake_sns', '~> 0.0.1'
+  s.add_development_dependency 'fake_sqs', '~> 0.0.10'
+  s.add_development_dependency 'fake_dynamo', '~> 0.1.3'
+end

--- a/spec/qu/backend/aws_spec.rb
+++ b/spec/qu/backend/aws_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'net/http'
+require 'qu-aws'
+
+AWS.config(
+  use_ssl:            false,
+  sqs_endpoint:       'localhost',
+  sqs_port:           5111,
+  dynamo_db_endpoint: 'localhost',
+  dynamo_db_port:     5112,
+  access_key_id:      'asdf',
+  secret_access_key:  'asdf',
+)
+
+describe Qu::Backend::AWS do
+  let(:dynamo) { AWS::DynamoDB.new }
+
+  def reset_service(service)
+    host = AWS.config.send("#{service}_endpoint")
+    port = AWS.config.send("#{service}_port")
+    Net::HTTP.new(host, port).request(Net::HTTP::Delete.new("/"))
+  end
+
+  before(:each) do |ex|
+    [
+      :sqs,
+      :dynamo_db,
+    ].each do |service|
+      reset_service(service)
+    end
+
+    ENV["QU_DYNAMO_TABLE_NAME"] = "qu_test"
+
+    dynamo.tables.create(ENV["QU_DYNAMO_TABLE_NAME"], 10, 5, {
+      :hash_key => {:namespace => :string},
+      :range_key => {:id => :string},
+    })
+  end
+
+  it_should_behave_like 'a backend'
+end

--- a/spec/qu/backend/mongo_spec.rb
+++ b/spec/qu/backend/mongo_spec.rb
@@ -2,81 +2,83 @@ require 'spec_helper'
 require 'qu-mongo'
 
 describe Qu::Backend::Mongo do
-  it_should_behave_like 'a backend'
+  it_should_behave_like 'a backend', :services => :mongo
 
-  describe 'connection' do
-    it 'should default the qu database' do
-      subject.connection.should be_instance_of(Mongo::DB)
-      subject.connection.name.should == 'qu'
-    end
+  if service_running?(:mongo)
+    describe 'connection' do
+      it 'should default the qu database' do
+        subject.connection.should be_instance_of(Mongo::DB)
+        subject.connection.name.should == 'qu'
+      end
 
-    it 'should use MONGOHQ_URL from heroku' do
-      begin
-        Mongo::MongoClient.any_instance.stub(:connect)
-        ENV['MONGOHQ_URL'] = 'mongodb://user:pw@host:10060/quspec'
-        subject.connection.name.should == 'quspec'
-        # debugger
-        subject.connection.connection.host_port.should == ['host', 10060]
-        subject.connection.connection.auths.should satisfy { |v|
-          # Not happy about this, but the format of the auths attribute differs depending on your installed mongo version
-          # mongo >= 1.8.4 uses symbols for hash keys
-          # mongo < 1.8.4 uses strings for hash keys
-          v == [{:db_name => 'quspec', :username => 'user', :password => 'pw'}] or
-          v ==  [{'db_name' => 'quspec', 'username' => 'user', 'password' => 'pw'}]
-        }
-      ensure
-        ENV.delete('MONGOHQ_URL')
+      it 'should use MONGOHQ_URL from heroku' do
+        begin
+          Mongo::MongoClient.any_instance.stub(:connect)
+          ENV['MONGOHQ_URL'] = 'mongodb://user:pw@host:10060/quspec'
+          subject.connection.name.should == 'quspec'
+          # debugger
+          subject.connection.connection.host_port.should == ['host', 10060]
+          subject.connection.connection.auths.should satisfy { |v|
+            # Not happy about this, but the format of the auths attribute differs depending on your installed mongo version
+            # mongo >= 1.8.4 uses symbols for hash keys
+            # mongo < 1.8.4 uses strings for hash keys
+            v == [{:db_name => 'quspec', :username => 'user', :password => 'pw'}] or
+            v ==  [{'db_name' => 'quspec', 'username' => 'user', 'password' => 'pw'}]
+          }
+        ensure
+          ENV.delete('MONGOHQ_URL')
+        end
+      end
+
+      context "Connection Failure" do
+        let(:retries_number) { 3 }
+        let(:retries_frequency) { 5 }
+
+        before do
+          subject.max_retries = retries_number
+          subject.retry_frequency = retries_frequency
+
+          Mongo::DB.any_instance.stub(:[]).and_raise(Mongo::ConnectionFailure)
+          subject.stub(:sleep)
+        end
+
+        it "raise error" do
+          expect { subject.queues }.to raise_error(Mongo::ConnectionFailure)
+        end
+
+        it "trying to reconect" do
+          subject.database.should_receive(:[]).exactly(4).times.and_raise(Mongo::ConnectionFailure)
+          expect { subject.queues }.to raise_error
+        end
+
+        it "sleep between tries" do
+          subject.should_receive(:sleep).with(5).ordered
+          subject.should_receive(:sleep).with(10).ordered
+          subject.should_receive(:sleep).with(15).ordered
+
+          expect { subject.queues }.to raise_error
+        end
+
       end
     end
 
-    context "Connection Failure" do
-      let(:retries_number) { 3 }
-      let(:retries_frequency) { 5 }
+    describe 'reserve' do
+      let(:worker) { Qu::Worker.new }
 
-      before do
-        subject.max_retries = retries_number
-        subject.retry_frequency = retries_frequency
-
-        Mongo::DB.any_instance.stub(:[]).and_raise(Mongo::ConnectionFailure)
-        subject.stub(:sleep)
+      describe "on mongo >=2" do
+        it 'should return nil when no jobs exist' do
+          subject.clear
+          Mongo::Collection.any_instance.should_receive(:find_and_modify).and_return(nil)
+          lambda { subject.reserve(worker, :block => false).should be_nil }.should_not raise_error
+        end
       end
 
-      it "raise error" do
-        expect { subject.queues }.to raise_error(Mongo::ConnectionFailure)
-      end
-
-      it "trying to reconect" do
-        subject.database.should_receive(:[]).exactly(4).times.and_raise(Mongo::ConnectionFailure)
-        expect { subject.queues }.to raise_error
-      end
-
-      it "sleep between tries" do
-        subject.should_receive(:sleep).with(5).ordered
-        subject.should_receive(:sleep).with(10).ordered
-        subject.should_receive(:sleep).with(15).ordered
-
-        expect { subject.queues }.to raise_error
-      end
-
-    end
-  end
-
-  describe 'reserve' do
-    let(:worker) { Qu::Worker.new }
-
-    describe "on mongo >=2" do
-      it 'should return nil when no jobs exist' do
-        subject.clear
-        Mongo::Collection.any_instance.should_receive(:find_and_modify).and_return(nil)
-        lambda { subject.reserve(worker, :block => false).should be_nil }.should_not raise_error
-      end
-    end
-
-    describe 'on mongo <2' do
-      it 'should return nil when no jobs exist' do
-        subject.clear
-        Mongo::Collection.any_instance.should_receive(:find_and_modify).and_raise(Mongo::OperationFailure)
-        lambda { subject.reserve(worker, :block => false).should be_nil }.should_not raise_error
+      describe 'on mongo <2' do
+        it 'should return nil when no jobs exist' do
+          subject.clear
+          Mongo::Collection.any_instance.should_receive(:find_and_modify).and_raise(Mongo::OperationFailure)
+          lambda { subject.reserve(worker, :block => false).should be_nil }.should_not raise_error
+        end
       end
     end
   end

--- a/spec/qu/backend/redis_spec.rb
+++ b/spec/qu/backend/redis_spec.rb
@@ -2,59 +2,61 @@ require 'spec_helper'
 require 'qu-redis'
 
 describe Qu::Backend::Redis do
-  it_should_behave_like 'a backend'
+  it_should_behave_like 'a backend', :services => :redis
 
   let(:worker) { Qu::Worker.new('default') }
 
-  describe 'completed' do
-    it 'should delete job' do
-      subject.enqueue(Qu::Payload.new(:klass => SimpleJob))
-      job = subject.reserve(worker)
-      subject.redis.exists("job:#{job.id}").should be_true
-      subject.completed(job)
-      subject.redis.exists("job:#{job.id}").should be_false
-    end
-  end
-
-  describe 'clear_workers' do
-    before { subject.register_worker worker }
-
-    it 'should delete worker key' do
-      subject.redis.get("worker:#{worker.id}").should_not be_nil
-      subject.clear_workers
-      subject.redis.get("worker:#{worker.id}").should be_nil
-    end
-  end
-
-  describe 'connection' do
-    it 'should create default connection if one not provided' do
-      subject.connection.should be_instance_of(Redis::Namespace)
-      subject.connection.namespace.should == :qu
-    end
-
-    it 'should use REDISTOGO_URL from heroku with namespace' do
-      begin
-        ENV['REDISTOGO_URL'] = 'redis://0.0.0.0:9876'
-        subject.connection.client.host.should == '0.0.0.0'
-        subject.connection.client.port.should == 9876
-        subject.connection.namespace.should == :qu
-      ensure
-        ENV.delete 'REDISTOGO_URL'
+  if service_running?(:redis)
+    describe 'completed' do
+      it 'should delete job' do
+        subject.enqueue(Qu::Payload.new(:klass => SimpleJob))
+        job = subject.reserve(worker)
+        subject.redis.exists("job:#{job.id}").should be_true
+        subject.completed(job)
+        subject.redis.exists("job:#{job.id}").should be_false
       end
     end
 
-    it 'should allow customizing the namespace' do
-      subject.namespace = :foobar
-      subject.connection.namespace.should == :foobar
-    end
-  end
+    describe 'clear_workers' do
+      before { subject.register_worker worker }
 
-  describe 'clear' do
-    it 'should delete jobs' do
-      job = subject.enqueue(Qu::Payload.new(:klass => SimpleJob))
-      subject.redis.exists("job:#{job.id}").should be_true
-      subject.clear
-      subject.redis.exists("job:#{job.id}").should be_false
+      it 'should delete worker key' do
+        subject.redis.get("worker:#{worker.id}").should_not be_nil
+        subject.clear_workers
+        subject.redis.get("worker:#{worker.id}").should be_nil
+      end
+    end
+
+    describe 'connection' do
+      it 'should create default connection if one not provided' do
+        subject.connection.should be_instance_of(Redis::Namespace)
+        subject.connection.namespace.should == :qu
+      end
+
+      it 'should use REDISTOGO_URL from heroku with namespace' do
+        begin
+          ENV['REDISTOGO_URL'] = 'redis://0.0.0.0:9876'
+          subject.connection.client.host.should == '0.0.0.0'
+          subject.connection.client.port.should == 9876
+          subject.connection.namespace.should == :qu
+        ensure
+          ENV.delete 'REDISTOGO_URL'
+        end
+      end
+
+      it 'should allow customizing the namespace' do
+        subject.namespace = :foobar
+        subject.connection.namespace.should == :foobar
+      end
+    end
+
+    describe 'clear' do
+      it 'should delete jobs' do
+        job = subject.enqueue(Qu::Payload.new(:klass => SimpleJob))
+        subject.redis.exists("job:#{job.id}").should be_true
+        subject.clear
+        subject.redis.exists("job:#{job.id}").should be_false
+      end
     end
   end
 end

--- a/spec/qu/payload_spec.rb
+++ b/spec/qu/payload_spec.rb
@@ -88,7 +88,7 @@ describe Qu::Payload do
       end
 
       it 'should call create on failure backend' do
-        Qu.failure = mock('a failure backend')
+        Qu.failure = double('a failure backend')
         Qu.failure.should_receive(:create).with(subject, error)
         subject.perform
       end

--- a/spec/qu/payload_spec.rb
+++ b/spec/qu/payload_spec.rb
@@ -74,7 +74,7 @@ describe Qu::Payload do
       let(:error) { Exception.new("Some kind of error") }
 
       before do
-        SimpleJob.stub!(:perform).and_raise(error)
+        SimpleJob.stub(:perform).and_raise(error)
       end
 
       it 'should call failed on backend' do

--- a/spec/qu/payload_spec.rb
+++ b/spec/qu/payload_spec.rb
@@ -33,6 +33,18 @@ describe Qu::Payload do
     end
   end
 
+  describe 'as_json' do
+    subject { Qu::Payload.new(:klass => SimpleJob, :args => ['test'], :id => 1) }
+
+    it 'returns hash of attributes' do
+      subject.as_json.should eq({
+        :klass => 'SimpleJob',
+        :args => ['test'],
+        :id => 1,
+      })
+    end
+  end
+
   describe 'perform' do
     subject { Qu::Payload.new(:klass => SimpleJob) }
 
@@ -81,6 +93,5 @@ describe Qu::Payload do
         subject.perform
       end
     end
-
   end
 end

--- a/spec/qu/payload_spec.rb
+++ b/spec/qu/payload_spec.rb
@@ -33,11 +33,11 @@ describe Qu::Payload do
     end
   end
 
-  describe 'as_json' do
+  describe 'attributes' do
     subject { Qu::Payload.new(:klass => SimpleJob, :args => ['test'], :id => 1) }
 
     it 'returns hash of attributes' do
-      subject.as_json.should eq({
+      subject.attributes.should eq({
         :klass => 'SimpleJob',
         :args => ['test'],
         :id => 1,

--- a/spec/qu/worker_spec.rb
+++ b/spec/qu/worker_spec.rb
@@ -13,7 +13,7 @@ describe Qu::Worker do
 
   describe 'work' do
     before do
-      Qu.stub!(:reserve).and_return(job)
+      Qu.stub(:reserve).and_return(job)
     end
 
     it 'should reserve a job' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,8 @@ module ServiceHelpers
         Mongo::MongoClient.from_uri(uri)
       end
 
+      p client
+
       client.ping
       true
     when "redis"
@@ -31,12 +33,15 @@ module ServiceHelpers
         Redis.connect(:url => url)
       end
 
+      p client
+
       client.ping
       true
     else
       false
     end
   rescue => exception
+    p exception
     false
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,48 @@ Bundler.require :test
 require 'qu'
 require 'qu/backend/spec'
 
+module ServiceHelpers
+  def service_running?(service)
+    case service.to_s
+    when "dynamo_db", "sqs"
+      host = AWS.config.send("#{service}_endpoint")
+      port = AWS.config.send("#{service}_port")
+      Net::HTTP.new(host, port).request(Net::HTTP::Get.new("/"))
+      true
+    when "mongo"
+      uri = ENV['MONGOHQ_URL'] || ENV['MONGOLAB_URI'] || ENV['BOXEN_MONGODB_URL']
+
+      client = if uri.empty?
+        Mongo::MongoClient.new
+      else
+        Mongo::MongoClient.from_uri(uri)
+      end
+
+      client.ping
+      true
+    when "redis"
+      url = ENV['REDISTOGO_URL'] || ENV['BOXEN_REDIS_URL']
+
+      client = if url.empty?
+        Redis.new
+      else
+        Redis.connect(:url => url)
+      end
+
+      client.ping
+      true
+    else
+      false
+    end
+  rescue => exception
+    false
+  end
+end
+
 RSpec.configure do |config|
+  config.include ServiceHelpers
+  config.extend ServiceHelpers
+
   config.before(:each) do
     Qu.backend = mock('a backend', :reserve => nil, :failed => nil, :completed => nil,
       :register_worker => nil, :unregister_worker => nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ RSpec.configure do |config|
   config.extend ServiceHelpers
 
   config.before(:each) do
-    Qu.backend = mock('a backend', :reserve => nil, :failed => nil, :completed => nil,
+    Qu.backend = double('a backend', :reserve => nil, :failed => nil, :completed => nil,
       :register_worker => nil, :unregister_worker => nil)
     Qu.failure = nil
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ module ServiceHelpers
     when "mongo"
       uri = ENV['MONGOHQ_URL'] || ENV['MONGOLAB_URI'] || ENV['BOXEN_MONGODB_URL']
 
-      client = if uri.empty?
+      client = if uri.nil? || uri.empty?
         Mongo::MongoClient.new
       else
         Mongo::MongoClient.from_uri(uri)
@@ -27,7 +27,7 @@ module ServiceHelpers
     when "redis"
       url = ENV['REDISTOGO_URL'] || ENV['BOXEN_REDIS_URL']
 
-      client = if url.empty?
+      client = if uri.nil? || url.empty?
         Redis.new
       else
         Redis.connect(:url => url)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,8 +20,6 @@ module ServiceHelpers
         Mongo::MongoClient.from_uri(uri)
       end
 
-      p client
-
       client.ping
       true
     when "redis"
@@ -32,8 +30,6 @@ module ServiceHelpers
       else
         Redis.connect(:url => url)
       end
-
-      p client
 
       client.ping
       true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'qu'
 require 'qu/backend/spec'
 
 RSpec.configure do |config|
-  config.before do
+  config.before(:each) do
     Qu.backend = mock('a backend', :reserve => nil, :failed => nil, :completed => nil,
       :register_worker => nil, :unregister_worker => nil)
     Qu.failure = nil


### PR DESCRIPTION
See what I did there. Yeaaaaaahhhhh. 

This adds an AWS backend and is the first step towards a better abstraction that I am hoping to work on. The AWS Connection makes it possible to use SNS or SQS to enqueue jobs and SQS to dequeue. All state of known queues and workers is stored in dynamodb. 

The abstraction I want to change is from "backend" to "state" and "queue". Right now, the requirements of a "backend" require storing arbitrary things (workers, queues) that all of the real and great queues don't support. Also, most of this arbitrary information is used only for UI purposes (of which there is not one currently). 

Separating backend into state and queue means that all queues can work with qu and one can store the UI state where it makes more sense (mysql, redis, mongo, dynamo, simpledb, whatever) or not at all. Hoping to work on that next, but need to power through the AWS stuff in order to see what was needed.

Also, this adds the idea of required services for a backend spec. It means if you provide services, we'll make sure they are up when the specs run and if they aren't we'll skip those specs so you dont have to have every queue and database in the world running with exactly the right options all the time to work on qu.
