### PR TITLE
Notify backends of job failure

### DIFF
--- a/lib/qu.rb
+++ b/lib/qu.rb
@@ -22,7 +22,7 @@ module Qu
 
   attr_accessor :logger, :graceful_shutdown, :instrumenter, :interval
 
-  def_delegators :backend, :push, :pop, :complete, :abort, :size, :clear
+  def_delegators :backend, :push, :pop, :complete, :abort, :fail, :size, :clear
 
   def backend
     @backend || raise("Qu backend not configured. Install one of the backend gems like qu-redis.")

--- a/lib/qu/backend/immediate.rb
+++ b/lib/qu/backend/immediate.rb
@@ -16,6 +16,9 @@ module Qu
       def abort(payload)
       end
 
+      def fail(payload)
+      end
+
       def pop(queue = 'default')
       end
 

--- a/lib/qu/backend/instrumented.rb
+++ b/lib/qu/backend/instrumented.rb
@@ -42,6 +42,13 @@ module Qu
         }
       end
 
+      def fail(payload)
+        instrument("fail.#{InstrumentationNamespace}") { |ipayload|
+          ipayload[:payload] = payload
+          @backend.fail(payload)
+        }
+      end
+
       def pop(queue_name = 'default')
         instrument("pop.#{InstrumentationNamespace}") { |ipayload|
           result = @backend.pop(queue_name)

--- a/lib/qu/backend/mongo.rb
+++ b/lib/qu/backend/mongo.rb
@@ -30,6 +30,9 @@ module Qu
         end
       end
 
+      def fail(payload)
+      end
+
       def complete(payload)
       end
 

--- a/lib/qu/backend/redis.rb
+++ b/lib/qu/backend/redis.rb
@@ -24,6 +24,9 @@ module Qu
         connection.rpush("queue:#{payload.queue}", payload.id)
       end
 
+      def fail(payload)
+      end
+
       def complete(payload)
         connection.del("job:#{payload.id}")
       end

--- a/lib/qu/backend/spec.rb
+++ b/lib/qu/backend/spec.rb
@@ -20,6 +20,10 @@ shared_examples_for 'a backend interface' do
     subject.abort payload
   end
 
+  it "can fail a payload" do
+    subject.fail payload
+  end
+
   it "can pop" do
     subject.pop
   end
@@ -127,6 +131,16 @@ shared_examples_for 'a backend' do
       subject.size(payload.queue).should == 0
       subject.abort(popped_payload)
       subject.size(payload.queue).should == 1
+    end
+  end
+
+  describe 'fail' do
+    before do
+      subject.fail(payload)
+    end
+
+    it 'should add the job back on the queue' do
+      subject.fail(payload)
     end
   end
 

--- a/lib/qu/backend/spec.rb
+++ b/lib/qu/backend/spec.rb
@@ -115,8 +115,8 @@ shared_examples_for 'a backend' do
   end
 
   describe 'complete' do
-    it 'should be defined' do
-      subject.respond_to?(:complete).should be_true
+    it 'should be defined and accept payload' do
+      subject.complete(payload)
     end
   end
 
@@ -135,11 +135,7 @@ shared_examples_for 'a backend' do
   end
 
   describe 'fail' do
-    before do
-      subject.fail(payload)
-    end
-
-    it 'should add the job back on the queue' do
+    it 'should be defined and accept payload' do
       subject.fail(payload)
     end
   end

--- a/lib/qu/backend/sqs.rb
+++ b/lib/qu/backend/sqs.rb
@@ -34,6 +34,17 @@ module Qu
         end
       end
 
+      def fail(payload)
+        if fake_sqs?
+          # should only get here in localhost; it is ok to remove this when
+          # fake_sqs supports changing a messages visibility timeout
+          payload.message.delete if payload.message
+          push(payload)
+        else
+          payload.message.visibility_timeout = 0
+        end
+      end
+
       def pop(queue_name = 'default')
         begin
           queue = connection.queues.named(queue_name)

--- a/lib/qu/failure.rb
+++ b/lib/qu/failure.rb
@@ -13,7 +13,7 @@ module Qu
     #
     # Returns nothing.
     def self.create(payload, exception)
-      instrument("failure.#{InstrumentationNamespace}") do |ipayload|
+      instrument("failure_create.#{InstrumentationNamespace}") do |ipayload|
         ipayload[:payload] = payload
         ipayload[:exception] = exception
 

--- a/lib/qu/failure.rb
+++ b/lib/qu/failure.rb
@@ -5,6 +5,13 @@ module Qu
   module Failure
     extend Qu::Instrumenter
 
+    # Public: Creates a failure for the given payload and exception using the
+    # current failure backend.
+    #
+    # payload - The Qu::Payload that raised an exception when performing.
+    # exception - The exception raised.
+    #
+    # Returns nothing.
     def self.create(payload, exception)
       instrument("failure.#{InstrumentationNamespace}") do |ipayload|
         ipayload[:payload] = payload
@@ -14,10 +21,12 @@ module Qu
       end
     end
 
+    # Public: Allows user to change failure backend.
     def self.backend=(backend)
       @backend = backend
     end
 
+    # Private: Returns the current failure backend.
     def self.backend
       @backend ||= Failure::Log
     end

--- a/lib/qu/instrumentation/log_subscriber.rb
+++ b/lib/qu/instrumentation/log_subscriber.rb
@@ -25,8 +25,8 @@ module Qu
         log_event(:abort, event)
       end
 
-      def failure(event)
-        log_event(:failure, event)
+      def fail(event)
+        log_event(:fail, event)
       end
 
       private

--- a/lib/qu/job.rb
+++ b/lib/qu/job.rb
@@ -1,7 +1,7 @@
 module Qu
   class Job
     include Qu::Hooks
-    define_hooks :push, :perform, :complete, :abort, :failure
+    define_hooks :push, :perform, :complete, :abort, :fail
 
     attr_accessor :payload
 

--- a/lib/qu/payload.rb
+++ b/lib/qu/payload.rb
@@ -32,13 +32,12 @@ module Qu
         end
       end
 
-      complete
+      job.run_hook(:complete) { Qu.complete(self) }
     rescue Qu::Worker::Abort
-      abort
+      job.run_hook(:abort) { Qu.abort(self) }
       raise
     rescue => exception
-      abort
-      job.run_hook(:failure, exception) { Qu::Failure.create(self, exception) }
+      job.run_hook(:fail, exception) { Qu.fail(self) }
     end
 
     # Internal: Pushes payload to backend.
@@ -65,14 +64,6 @@ module Qu
     end
 
     private
-
-    def complete
-      job.run_hook(:complete) { Qu.complete(self) }
-    end
-
-    def abort
-      job.run_hook(:abort) { Qu.abort(self) }
-    end
 
     def constantize(class_name)
       return unless class_name

--- a/lib/qu/payload.rb
+++ b/lib/qu/payload.rb
@@ -38,6 +38,7 @@ module Qu
       raise
     rescue => exception
       job.run_hook(:fail, exception) { Qu.fail(self) }
+      Qu::Failure.create(self, exception)
     end
 
     # Internal: Pushes payload to backend.

--- a/spec/qu/instrumentation/log_subscriber_spec.rb
+++ b/spec/qu/instrumentation/log_subscriber_spec.rb
@@ -73,7 +73,7 @@ describe Qu::Instrumentation::LogSubscriber do
     end
   end
 
-  it "logs failure and abort when exception happens" do
+  it "logs fail" do
     payload = SimpleJob.create
     payload.job.stub(:perform).and_raise(StandardError.new)
 
@@ -81,10 +81,7 @@ describe Qu::Instrumentation::LogSubscriber do
       payload.perform
       flunk # should not get here
     rescue => exception
-      line = find_line('Qu abort')
-      line.should include(payload.to_s)
-
-      line = find_line('Qu failure')
+      line = find_line('Qu fail')
       line.should include(payload.to_s)
 
       # should not get to complete

--- a/spec/qu/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/qu/instrumentation/statsd_subscriber_spec.rb
@@ -69,27 +69,27 @@ describe Qu::Instrumentation::StatsdSubscriber do
     end
   end
 
-  it "instruments abort when exception happens" do
+  it "instruments fail when exception happens" do
     payload = SimpleJob.create
     payload.job.stub(:perform).and_raise(StandardError.new)
     begin
       payload.perform
       flunk # should not get here
     rescue => exception
-      assert_timer "qu.op.abort"
-      assert_timer "qu.job.SimpleJob.abort"
+      assert_timer "qu.op.fail"
+      assert_timer "qu.job.SimpleJob.fail"
     end
   end
 
-  it "instruments failure when exception happens" do
+  it "instruments fail" do
     payload = SimpleJob.create
     payload.job.stub(:perform).and_raise(StandardError.new)
     begin
       payload.perform
       flunk # should not get here
     rescue => exception
-      assert_timer "qu.op.failure"
-      assert_timer "qu.job.SimpleJob.failure"
+      assert_timer "qu.op.fail"
+      assert_timer "qu.job.SimpleJob.fail"
     end
   end
 end

--- a/spec/qu/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/qu/instrumentation/statsd_subscriber_spec.rb
@@ -69,7 +69,7 @@ describe Qu::Instrumentation::StatsdSubscriber do
     end
   end
 
-  it "instruments fail when exception happens" do
+  it "instruments fail" do
     payload = SimpleJob.create
     payload.job.stub(:perform).and_raise(StandardError.new)
     begin
@@ -81,15 +81,15 @@ describe Qu::Instrumentation::StatsdSubscriber do
     end
   end
 
-  it "instruments fail" do
+  it "instruments failure create" do
     payload = SimpleJob.create
     payload.job.stub(:perform).and_raise(StandardError.new)
     begin
       payload.perform
       flunk # should not get here
     rescue => exception
-      assert_timer "qu.op.fail"
-      assert_timer "qu.job.SimpleJob.fail"
+      assert_timer "qu.op.failure_create"
+      assert_timer "qu.job.SimpleJob.failure_create"
     end
   end
 end

--- a/spec/qu/job_spec.rb
+++ b/spec/qu/job_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Qu::Job do
-  %w(push perform complete abort failure).each do |hook|
+  %w(push perform complete abort fail).each do |hook|
     it "should define hooks for #{hooks}" do
       Qu::Job.should respond_to("before_#{hook}")
       Qu::Job.should respond_to("around_#{hook}")

--- a/spec/qu/payload_spec.rb
+++ b/spec/qu/payload_spec.rb
@@ -123,6 +123,11 @@ describe Qu::Payload do
         subject.job.should_receive(:run_hook).with(:fail, error)
         subject.perform
       end
+
+      it 'should call create for failure backend' do
+        Qu::Failure.should_receive(:create).with(subject, error)
+        subject.perform
+      end
     end
   end
 

--- a/spec/qu/payload_spec.rb
+++ b/spec/qu/payload_spec.rb
@@ -89,6 +89,11 @@ describe Qu::Payload do
         lambda { subject.perform }.should raise_error(Qu::Worker::Abort)
       end
 
+      it 'should not call complete' do
+        Qu.should_not_receive(:complete)
+        lambda { subject.perform }.should raise_error(Qu::Worker::Abort)
+      end
+
       it 'should run abort hook' do
         subject.job.stub(:run_hook).and_yield
         subject.job.should_receive(:run_hook).with(:abort)

--- a/spec/qu/payload_spec.rb
+++ b/spec/qu/payload_spec.rb
@@ -113,6 +113,11 @@ describe Qu::Payload do
         subject.perform
       end
 
+      it 'should call fail' do
+        Qu.should_receive(:fail).with(subject)
+        subject.perform
+      end
+
       it 'should run fail hook' do
         subject.job.stub(:run_hook).and_yield
         subject.job.should_receive(:run_hook).with(:fail, error)

--- a/spec/qu/payload_spec.rb
+++ b/spec/qu/payload_spec.rb
@@ -108,15 +108,9 @@ describe Qu::Payload do
         subject.perform
       end
 
-      it 'should run abort hook' do
+      it 'should run fail hook' do
         subject.job.stub(:run_hook).and_yield
-        subject.job.should_receive(:run_hook).with(:abort)
-        subject.perform
-      end
-
-      it 'should run failure hook' do
-        subject.job.stub(:run_hook).and_yield
-        subject.job.should_receive(:run_hook).with(:failure, error)
+        subject.job.should_receive(:run_hook).with(:fail, error)
         subject.perform
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,6 +63,7 @@ RSpec.configure do |config|
       :pop => nil,
       :complete => nil,
       :abort => nil,
+      :fail => nil,
     })
   end
 end


### PR DESCRIPTION
This fixes #78. Backends now know that a given payload caused a failure and can either fail silently or do whatever is appropriate. In addition to backends being notified of failure, the failure backend is also notified for sending the exception somewhere (ie: log, exceptional, airbrake, etc.).
