### PR TITLE
Relax Rails dependency and depend on railties instead of rails itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Qu was created to overcome some shortcomings in the existing queuing libraries t
 
 ## Installation
 
-### Rails 3
+### Rails 3 and 4
 
 Decide which backend you want to use and add the gem to your `Gemfile`.
 

--- a/lib/qu/instrumentation/log_subscriber.rb
+++ b/lib/qu/instrumentation/log_subscriber.rb
@@ -5,6 +5,11 @@ require 'active_support/log_subscriber'
 module Qu
   module Instrumentation
     class LogSubscriber < ::ActiveSupport::LogSubscriber
+
+      def logger
+        LogSubscriber.logger
+      end
+
       def pop(event)
         log_event(:pop, event)
       end

--- a/qu-rails.gemspec
+++ b/qu-rails.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files -- lib | grep rails`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency 'rails', '~> 3.2'
+  s.add_dependency 'railties', '>= 3.2', '< 5'
   s.add_dependency 'qu', Qu::VERSION
 end

--- a/spec/qu/instrumentation/log_subscriber_spec.rb
+++ b/spec/qu/instrumentation/log_subscriber_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'qu/backend/redis'
 require 'qu/instrumentation/log_subscriber'
 
 describe Qu::Instrumentation::LogSubscriber do


### PR DESCRIPTION
The Railties API hasn't changed between Rails 3 and 4, so the dependency can be made compatible with Rails 4 as well. Also changed it to depend on `railties` instead of `rails` itself.
