### PR TITLE
Bulk processing for workers

### DIFF
--- a/lib/qu/backend/batch.rb
+++ b/lib/qu/backend/batch.rb
@@ -1,0 +1,44 @@
+require 'qu/batch_payload'
+require 'qu/backend/wrapper'
+
+module Qu
+  module Backend
+
+    # backend that takes messages in bulk for processing
+    class Batch
+      include Wrapper
+
+      def_delegators :@backend, :size, :clear, :push
+
+      def complete(payload)
+        @backend.batch_complete(payload.payloads)
+      end
+
+      def abort(payload)
+        @backend.batch_abort(payload.payloads)
+      end
+
+      def fail(payload)
+        @backend.batch_fail(payload.payloads)
+      end
+
+      def pop(queue_name = 'default')
+        payloads = @backend.batch_pop( queue_name, 10 ) # size should be configurable
+        if payloads && !payloads.empty?
+          result = payloads.group_by { |payload| payload.klass }.map do |klass,payloads|
+            Qu::BatchPayload.new( :queue => queue_name, :klass => klass, :payloads => payloads )
+          end
+
+          current = result.shift
+
+          result.each do |payload|
+            @backend.batch_push(payload.payloads)
+          end
+
+          current
+        end
+      end
+
+    end
+  end
+end

--- a/lib/qu/backend/instrumented.rb
+++ b/lib/qu/backend/instrumented.rb
@@ -1,25 +1,12 @@
 require 'forwardable'
+require 'qu/backend/wrapper'
 
 module Qu
   module Backend
     # Internal: Backend that wraps all backends with instrumentation.
     class Instrumented < Base
-      extend Forwardable
+      include Wrapper
       include Qu::Instrumenter
-
-      def self.wrap(backend)
-        if backend.nil?
-          backend
-        else
-          new(backend)
-        end
-      end
-
-      def_delegators :@backend, :connection, :connection=
-
-      def initialize(backend)
-        @backend = backend
-      end
 
       def push(payload)
         instrument("push.#{InstrumentationNamespace}") { |ipayload|

--- a/lib/qu/backend/sqs.rb
+++ b/lib/qu/backend/sqs.rb
@@ -4,23 +4,30 @@ require 'aws/sqs'
 module Qu
   module Backend
     class SQS < Base
+
       def push(payload)
-        # id does not really matter for sqs as they have ids already so i'm just
-        # sending something relatively unique for errors and what not
-        payload.id = Digest::SHA1.hexdigest(payload.to_s + Time.now.to_s)
-
-        queue = begin
-          connection.queues.named(payload.queue)
-        rescue ::AWS::SQS::Errors::NonExistentQueue
-          connection.queues.create(payload.queue)
-        end
-
-        queue.send_message(dump(payload.attributes_for_push))
+        find_or_create_queue(payload.queue).send_message(generate_dump(payload))
         payload
+      end
+
+      def batch_push(payloads)
+        map_by_queue(payloads) do |queue,group|
+          messages = group.map { |payload| generate_dump(payload) }
+          find_or_create_queue(queue).batch_send(*messages)
+        end.flatten
       end
 
       def complete(payload)
         payload.message.delete if payload.message
+      end
+
+      def batch_complete(payloads)
+        begin
+          map_by_queue(payloads) do |queue,group|
+            connection.queues.named(queue).batch_delete(*group)
+          end
+        rescue ::AWS::SQS::Errors::NonExistentQueue
+        end
       end
 
       def abort(payload)
@@ -34,13 +41,15 @@ module Qu
       def pop(queue_name = 'default')
         begin
           queue = connection.queues.named(queue_name)
+          create_payload(queue.receive_message)
+        rescue ::AWS::SQS::Errors::NonExistentQueue
+        end
+      end
 
-          if message = queue.receive_message
-            doc = load(message.body)
-            payload = Payload.new(doc)
-            payload.message = message
-            return payload
-          end
+      def batch_pop( queue_name = 'default', limit = 10 )
+        begin
+          queue = connection.queues.named(queue_name)
+          queue.receive_messages( :limit => limit ).map { |message| create_payload(message) }
         rescue ::AWS::SQS::Errors::NonExistentQueue
         end
       end
@@ -71,6 +80,43 @@ module Qu
 
       def connection
         @connection ||= ::AWS::SQS.new
+      end
+
+      private
+
+      def find_or_create_queue(queue_name)
+        begin
+          connection.queues.named(queue_name)
+        rescue ::AWS::SQS::Errors::NonExistentQueue
+          connection.queues.create(queue_name)
+        end
+      end
+
+      def create_payload(message)
+        if message
+          doc = load(message.body)
+          payload = Payload.new(doc)
+          payload.message = message
+          payload
+        end
+      end
+
+      def generate_dump(payload)
+        dump(set_message_id(payload).attributes_for_push)
+      end
+
+      def map_by_queue( payloads )
+        return unless payloads
+        payloads.group_by { |p| p.queue }.map do |queue,group|
+          yield(queue,group)
+        end
+      end
+
+      def set_message_id(payload)
+        # id does not really matter for sqs as they have ids already so i'm just
+        # sending something relatively unique for errors and what not
+        payload.id = Digest::SHA1.hexdigest(payload.to_s + Time.now.to_s)
+        payload
       end
 
     end

--- a/lib/qu/backend/wrapper.rb
+++ b/lib/qu/backend/wrapper.rb
@@ -1,0 +1,29 @@
+module Qu
+  module Backend
+    module Wrapper
+      extend Forwardable
+      def_delegators :@backend, :connection, :connection=
+
+      def self.included( base )
+        base.extend(ClassMethods, Forwardable)
+      end
+
+      def initialize(backend)
+        @backend = backend
+      end
+
+      module ClassMethods
+
+        def wrap(backend)
+          if backend.nil?
+            backend
+          else
+            new(backend)
+          end
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/qu/batch_payload.rb
+++ b/lib/qu/batch_payload.rb
@@ -1,0 +1,12 @@
+require 'qu/payload'
+
+module Qu
+  class BatchPayload < Payload
+
+    def initialize( options )
+      super
+      self.args = self.payloads.map(&:args).flatten
+    end
+
+  end
+end

--- a/spec/qu/backend/batch_spec.rb
+++ b/spec/qu/backend/batch_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'qu/backend/batch'
+require 'qu-sqs'
+
+Qu::Specs.setup_fake_sqs
+
+describe Qu::Backend::Batch do
+
+  if Qu::Specs.perform?(described_class, :sqs)
+    before do
+      Qu::Specs.reset_service(:sqs)
+    end
+
+    subject do
+      described_class.wrap(Qu::Backend::SQS.new)
+    end
+
+    it_should_behave_like 'a backend interface'
+
+    context 'pop-ing items in batches' do
+
+      before do
+        Qu.backend = subject
+      end
+
+      it 'should correctly pop all items in a single payload' do
+        10.times do |n|
+          SimpleNumericJob.create(n)
+        end
+
+        expect(subject.size).to eq(10)
+
+        result = subject.pop
+
+        expect(result.klass).to eq(SimpleNumericJob)
+        expect(result.args.sort).to eq((0..9).to_a)
+        expect(subject.size).to eq(0)
+      end
+
+      it 'should correctly separate items by type' do
+        (1..5).each do |n|
+          SimpleNumericJob.create(n)
+        end
+
+        (6..10).each do |n|
+          OtherNumericJob.create(n)
+        end
+
+        expectations = {
+          SimpleNumericJob => (1..5).to_a,
+          OtherNumericJob => (6..10).to_a
+        }
+
+        result = subject.pop
+
+        expect(expectations).to include(result.klass)
+        expect(result.payloads.size).to eq(5)
+        expect(result.args.sort).to eq( expectations[result.klass] )
+        expect(subject.size).to eq(5)
+
+        other_result = subject.pop
+
+        expect(expectations).to include(other_result.klass)
+        expect(other_result.payloads.size).to eq(5)
+        expect(other_result.args.sort).to eq( expectations[other_result.klass] )
+        expect(subject.size).to eq(0)
+
+      end
+
+    end
+
+  end
+
+end

--- a/spec/qu/backend/sqs_spec.rb
+++ b/spec/qu/backend/sqs_spec.rb
@@ -7,27 +7,17 @@ require 'spec_helper'
 require 'net/http'
 require 'qu-sqs'
 
-AWS.config(
-  use_ssl:            false,
-  sqs_endpoint:       'localhost',
-  sqs_port:           5111,
-  access_key_id:      'asdf',
-  secret_access_key:  'asdf',
-)
+Qu::Specs.setup_fake_sqs
 
 describe Qu::Backend::SQS do
-  def reset_service(service)
-    host = AWS.config.send("#{service}_endpoint")
-    port = AWS.config.send("#{service}_port")
-    Net::HTTP.new(host, port).request(Net::HTTP::Delete.new("/"))
-  end
 
   if Qu::Specs.perform?(described_class, :sqs)
     before(:each) do
-      reset_service(:sqs)
+      Qu::Specs.reset_service(:sqs)
     end
 
     it_should_behave_like 'a backend'
     it_should_behave_like 'a backend interface'
+    it_should_behave_like 'a batch capable backend'
   end
 end

--- a/spec/qu/batch_payload_spec.rb
+++ b/spec/qu/batch_payload_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'qu/batch_payload'
+
+class ExampleJob < Qu::Job
+
+  attr_reader :numbers
+
+  def initialize(*numbers)
+    @numbers = numbers
+  end
+
+end
+
+describe Qu::BatchPayload do
+
+  let :payloads do
+    (1..10).map do |n|
+      Qu::Payload.new(:klass => "ExampleJob", :args => n)
+    end
+  end
+
+  let :batch do
+    Qu::BatchPayload.new(:payloads => payloads, :queue => 'default', :klass => 'ExampleJob')
+  end
+
+  it 'should set the args to the collection of args of all payloads' do
+    expect(batch.args).to eq((1..10).to_a)
+  end
+
+  it 'should create the worker class with the available args' do
+    expect(batch.job.numbers).to eq((1..10).to_a)
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,23 @@ Dir[root_path.join("spec/support/**/*.rb")].each { |f| require f }
 
 module Qu
   module Specs
+
+    def self.setup_fake_sqs
+      AWS.config(
+        use_ssl:            false,
+        sqs_endpoint:       'localhost',
+        sqs_port:           5111,
+        access_key_id:      'asdf',
+        secret_access_key:  'asdf',
+      )
+    end
+
+    def self.reset_service(service)
+      host = AWS.config.send("#{service}_endpoint")
+      port = AWS.config.send("#{service}_port")
+      Net::HTTP.new(host, port).request(Net::HTTP::Delete.new("/"))
+    end
+
     def self.perform?(class_under_spec, *service_names)
       services = service_names.flatten
       return true if services.size == 0
@@ -53,6 +70,7 @@ module Qu
         false
       end
     rescue => exception
+      puts "Failed to talk to service #{exception.message}\n#{exception.backtrace.join("\n")}"
       false
     end
   end


### PR DESCRIPTION
The rationale behind this is that sometimes you have workers that publish work in units but would be better served by taking the work in batches.

The best example of this is `solr`/`elasticsearch`, when integrated, most of the time you will want to work with them publishing every change, but then it's much more efficient to process them in batches given they both offer batch/bulk update interfaces. So, instead of incurring the cost of publishing every document at `solr`/`elasticsearch`, you only pay the price once for every 10 documents.

Other than that, there's the fact that `SQS` itself has a much higher latency and taking in more messages instead of just one is much better.

This is mostly a proof of concept, but I have hacked a solution to do this before and it would be nice to have the queue supporting this out of the box.
