### PR TITLE
Upgrading fake_sqs, now it does support changing message visibility

### DIFF
--- a/lib/qu/backend/sqs.rb
+++ b/lib/qu/backend/sqs.rb
@@ -24,25 +24,11 @@ module Qu
       end
 
       def abort(payload)
-        if fake_sqs?
-          # should only get here in localhost; it is ok to remove this when
-          # fake_sqs supports changing a messages visibility timeout
-          payload.message.delete if payload.message
-          push(payload)
-        else
-          payload.message.visibility_timeout = 0
-        end
+        payload.message.visibility_timeout = 0
       end
 
       def fail(payload)
-        if fake_sqs?
-          # should only get here in localhost; it is ok to remove this when
-          # fake_sqs supports changing a messages visibility timeout
-          payload.message.delete if payload.message
-          push(payload)
-        else
-          payload.message.visibility_timeout = 0
-        end
+        payload.message.visibility_timeout = 0
       end
 
       def pop(queue_name = 'default')
@@ -87,11 +73,6 @@ module Qu
         @connection ||= ::AWS::SQS.new
       end
 
-      private
-
-      def fake_sqs?
-        ::AWS.config.sqs_endpoint == "localhost"
-      end
     end
   end
 end

--- a/qu-sqs.gemspec
+++ b/qu-sqs.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'aws-sdk', '~> 1.0'
   s.add_dependency 'qu', Qu::VERSION
 
-  s.add_development_dependency 'fake_sqs', '~> 0.0.10'
+  s.add_development_dependency 'fake_sqs', '~> 0.1.0'
 end


### PR DESCRIPTION
There's no need to have special handling for `fake_sqs` anymore since it now supports setting visibility for a single message.
