### PR TITLE
Return true on running? check, otherwise it will never run all specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,10 @@ module Qu
       return true if services.size == 0
 
       down_services = services.select { |service| !running?(service) }
-      unless down_services.empty?
+      if down_services.any?
         puts "Skipping #{class_under_spec}. Required services are not running (#{down_services.join(', ')})."
+      else
+        true
       end
     end
 


### PR DESCRIPTION
This is already part of #82 but given it still needs a lot of work, it would be nice to have this in before. If `true` is not returned here it will never see that the services are actually running and won't make all specs run on `unattended_spec`.
