### PR TITLE
Configuring travis-ci build to run against rails 4 and ruby 2.1 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,12 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
 services:
   - mongodb
   - redis
 script: bundle exec rake unattended_spec
 cache: bundler
+gemfile:
+  - Gemfile
+  - Gemfile-rails4

--- a/Gemfile-rails4
+++ b/Gemfile-rails4
@@ -1,0 +1,5 @@
+original_gemfile = File.join(File.dirname(__FILE__), 'Gemfile')
+
+eval IO.read(original_gemfile)
+
+gem 'railties', '~> 4.0'


### PR DESCRIPTION
There you go, separate gemfile for Rails 4 builds at travis-ci.
