### PR TITLE
Use Queue in memory backend

### DIFF
--- a/lib/qu/backend/memory.rb
+++ b/lib/qu/backend/memory.rb
@@ -19,7 +19,7 @@ module Qu
       def push(payload)
         payload.id = SecureRandom.uuid
         queue_for(payload.queue) do |queue|
-          queue << payload.id
+          queue.push(payload.id)
           @messages[payload.id] = dump(payload.attributes_for_push)
           payload
         end
@@ -40,7 +40,7 @@ module Qu
 
       def pop(queue_name = 'default')
         queue_for(queue_name) do |queue|
-          if id = queue.shift
+          if id = queue.pop(true) # nonblocking pop
             payload = Payload.new(load(@messages[id]))
             @pending[id] = payload
             payload
@@ -60,9 +60,9 @@ module Qu
 
       def queue_for(queue)
         if block_given?
-          synchronize { yield(@queues[queue] ||= []) }
+          synchronize { yield(@queues[queue] ||= Queue.new) }
         else
-          synchronize { @queues[queue] ||= [] }
+          synchronize { @queues[queue] ||= Queue.new }
         end
       end
     end

--- a/lib/qu/backend/memory.rb
+++ b/lib/qu/backend/memory.rb
@@ -40,10 +40,16 @@ module Qu
 
       def pop(queue_name = 'default')
         queue_for(queue_name) do |queue|
-          if id = queue.pop(true) # nonblocking pop
-            payload = Payload.new(load(@messages[id]))
-            @pending[id] = payload
-            payload
+          begin
+            if id = queue.pop(true) # nonblocking pop
+              payload = Payload.new(load(@messages[id]))
+              @pending[id] = payload
+              payload
+            end
+          rescue ThreadError => e
+            unless e.message =~ /queue empty/
+              raise e
+            end
           end
         end
       end

--- a/lib/qu/backend/memory.rb
+++ b/lib/qu/backend/memory.rb
@@ -40,15 +40,17 @@ module Qu
 
       def pop(queue_name = 'default')
         queue_for(queue_name) do |queue|
-          begin
-            if id = queue.pop(true) # nonblocking pop
-              payload = Payload.new(load(@messages[id]))
-              @pending[id] = payload
-              payload
-            end
-          rescue ThreadError => e
-            unless e.message =~ /queue empty/
-              raise e
+          unless queue.empty?
+            begin
+              if id = queue.pop(true) # nonblocking pop
+                payload = Payload.new(load(@messages[id]))
+                @pending[id] = payload
+                payload
+              end
+            rescue ThreadError => e
+              unless e.message =~ /queue empty/
+                raise e
+              end
             end
           end
         end


### PR DESCRIPTION
Not sure if this is an improvement or not, but it was easy to try. Popping an empty queue now requires exception handling, so there might be a performance degradation. If so it's probably not worth the change.
