### PR TITLE
NSQ HTTP backend

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,14 +29,14 @@ RSpec::Core::RakeTask.new(:spec) do |t|
 end
 
 namespace :spec do
-  Backends = %w(mongo redis)
+  Backends = %w(mongo redis nsq)
 
   Backends.each do |backend|
     desc "Run specs for #{backend} backend"
     RSpec::Core::RakeTask.new(backend) do |t|
       t.rspec_opts = %w[--color]
       t.verbose = false
-      t.pattern = "spec/qu/backend/#{backend}_spec.rb"
+      t.pattern = "spec/qu/backend/#{backend}*_spec.rb"
     end
   end
 

--- a/lib/qu-nsq-http.rb
+++ b/lib/qu-nsq-http.rb
@@ -1,0 +1,4 @@
+require 'qu'
+require 'qu/backend/nsq_http'
+
+Qu.backend = Qu::Backend::NSQHTTP.new

--- a/lib/qu/backend/nsq_http.rb
+++ b/lib/qu/backend/nsq_http.rb
@@ -1,0 +1,46 @@
+require 'net/http'
+require 'securerandom'
+
+module Qu
+  module Backend
+    class NSQHTTP < Base
+      attr_writer :channel_name
+
+      class NSQError < StandardError
+      end
+
+      def push(payload)
+        payload.id = SecureRandom.uuid
+        response = connection.post("/pub?topic=#{payload.queue}", dump(payload.attributes_for_push))
+        raise NSQError, "Push to NSQ unsuccessful: #{response.inspect}" unless response.code =~ /^2/
+        payload
+      end
+
+      # See http://dev.bitly.com/nsq.html#v3_nsq_stats
+      def size(queue_name = 'default')
+        size = 0
+        response = connection.get("/stats?format=json")
+        stats = Qu.load_json(response.body)['data']
+        if topic = stats['topics'].detect { |topic| topic['topic_name'] == queue_name }
+          if channel = topic['channels'].detect { |channel| channel['channel_name'] == channel_name }
+            size = channel['depth'] + channel['deferred_count']
+          end
+        end
+        size
+      end
+
+      def clear(queue_name = 'default')
+        response = connection.post("/channel/empty?topic=#{queue_name}&channel=#{channel_name}", "")
+        response.body
+      end
+
+      def channel_name
+        @channel_name ||= 'qu'
+      end
+
+      def connection
+        @connection ||= Net::HTTP.new('127.0.0.1', '4151')
+      end
+    end
+  end
+end

--- a/lib/qu/backend/spec.rb
+++ b/lib/qu/backend/spec.rb
@@ -55,38 +55,12 @@ shared_examples_for 'a backend interface' do
 end
 
 shared_examples_for 'a backend' do
+  it_should_behave_like 'a pushing backend'
+
   let(:payload) { Qu::Payload.new(:klass => SimpleJob) }
 
   before do
     subject.clear(payload.queue)
-  end
-
-  describe 'push' do
-    it 'should return a payload' do
-      subject.push(payload).should be_instance_of(Qu::Payload)
-    end
-
-    it 'should set the payload id' do
-      subject.push(payload)
-      payload.id.should_not be_nil
-    end
-
-    it 'should add a job to the queue' do
-      subject.push(payload)
-      payload.queue.should == 'default'
-      subject.size(payload.queue).should == 1
-    end
-
-    it 'should assign a different job id for the same job pushed multiple times' do
-      first = subject.push(payload).id
-      second = subject.push(payload).id
-      first.should_not eq(second)
-    end
-
-    it 'should enqueue the attributes for push' do
-      payload.should_receive(:attributes_for_push).and_return({})
-      subject.push(payload)
-    end
   end
 
   describe 'pop' do
@@ -145,6 +119,54 @@ shared_examples_for 'a backend' do
     end
   end
 
+  describe 'connection=' do
+    it 'should allow setting the connection' do
+      connection = double('a connection')
+      subject.connection = connection
+      subject.connection.should == connection
+    end
+
+    it 'should provide a default connection' do
+      subject.connection.should_not be_nil
+    end
+  end
+end
+
+shared_examples_for 'a pushing backend' do
+  let(:payload) { Qu::Payload.new(:klass => SimpleJob) }
+
+  before do
+    subject.clear(payload.queue)
+  end
+
+  describe 'push' do
+    it 'should return a payload' do
+      subject.push(payload).should be_instance_of(Qu::Payload)
+    end
+
+    it 'should set the payload id' do
+      subject.push(payload)
+      payload.id.should_not be_nil
+    end
+
+    it 'should add a job to the queue' do
+      subject.push(payload)
+      payload.queue.should == 'default'
+      subject.size(payload.queue).should == 1
+    end
+
+    it 'should assign a different job id for the same job pushed multiple times' do
+      first = subject.push(payload).id
+      second = subject.push(payload).id
+      first.should_not eq(second)
+    end
+
+    it 'should enqueue the attributes for push' do
+      payload.should_receive(:attributes_for_push).and_return({})
+      subject.push(payload)
+    end
+  end
+
   describe 'size' do
     it 'should use the default queue by default' do
       subject.size.should == 0
@@ -165,18 +187,6 @@ shared_examples_for 'a backend' do
       subject.push(payload)
       subject.clear('other')
       subject.size(payload.queue).should == 1
-    end
-  end
-
-  describe 'connection=' do
-    it 'should allow setting the connection' do
-      connection = double('a connection')
-      subject.connection = connection
-      subject.connection.should == connection
-    end
-
-    it 'should provide a default connection' do
-      subject.connection.should_not be_nil
     end
   end
 end

--- a/qu-nsq-http.gemspec
+++ b/qu-nsq-http.gemspec
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require "qu/version"
+
+Gem::Specification.new do |s|
+  s.name        = "qu-nsq-http"
+  s.version     = Qu::VERSION
+  s.authors     = ["Grant Rodgers"]
+  s.email       = ["grantr@gmail.com"]
+  s.homepage    = "http://github.com/bkeepers/qu"
+  s.summary     = "NSQ HTTP backend for qu"
+  s.description = "NSQ HTTP backend for qu"
+
+  s.files         = `git ls-files -- lib | grep nsq-http`.split("\n")
+  s.require_paths = ["lib"]
+
+  s.add_dependency 'qu', Qu::VERSION
+
+  s.add_development_dependency 'nsq-cluster'
+end

--- a/spec/qu/backend/nsq_http_spec.rb
+++ b/spec/qu/backend/nsq_http_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 require 'qu-nsq-http'
 
 describe Qu::Backend::NSQHTTP do
-
-  it_should_behave_like 'a pushing backend'
-  it_should_behave_like 'a backend interface'
+  if Qu::Specs.perform?(described_class, :nsq)
+    it_should_behave_like 'a pushing backend'
+    it_should_behave_like 'a backend interface'
+  end
 end

--- a/spec/qu/backend/nsq_http_spec.rb
+++ b/spec/qu/backend/nsq_http_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'qu-nsq-http'
+
+describe Qu::Backend::NSQHTTP do
+
+  it_should_behave_like 'a pushing backend'
+  it_should_behave_like 'a backend interface'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,8 +51,8 @@ module Qu
         client.ping
         true
       when "nsq"
-        uri = 'http://127.0.0.1:4151'
-        Net::HTTP.get(uri, '/ping')
+        uri = URI('http://127.0.0.1:4151/ping')
+        Net::HTTP.get(uri)
         true
       else
         false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,10 @@ module Qu
 
         client.ping
         true
+      when "nsq"
+        uri = 'http://127.0.0.1:4151'
+        Net::HTTP.get(uri, '/ping')
+        true
       else
         false
       end


### PR DESCRIPTION
This backend supports the NSQ HTTP api with no extra dependencies. It can only push, get queue size, and clear queues.

I split the backend shared specs internally into pushing specs (push, size, clear) and other. Future shared push specs should go in the `a pushing backend` group.

/cc @jnunemaker @bkeepers
