### PR TITLE
Relax Rails dependency

### DIFF
--- a/qu-rails.gemspec
+++ b/qu-rails.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files -- lib | grep rails`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency 'rails', '~>3.0'
+  s.add_dependency 'rails', '>=3.0'
   s.add_dependency 'qu', Qu::VERSION
 end


### PR DESCRIPTION
`qu-rails` is just a Railtie that sets up logging and adds the rake task. None of that changed between Rails 3 and 4.
