### PR TITLE
Remove rails2 from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,6 @@ gem 'qu-redis'
 
 That's all you need to do!
 
-### Rails 2
-
-Decide which backend you want to use and add the gem to `config.gems` in `environment.rb`:
-
-``` ruby
-config.gem 'qu-redis'
-````
-
-To load the rake tasks, add the following to your `Rakefile`:
-
-``` ruby
-require 'qu/tasks'
-```
-
 ## Usage
 
 Jobs are defined by extending the `Qu::Job` class:


### PR DESCRIPTION
I think rails2 it`s not supported anymore, gemspec limit rails to 3.2 https://github.com/bkeepers/qu/blob/master/qu-rails.gemspec#L17
and tests not run for rails 2.
